### PR TITLE
uox3 cmake, windows build only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15.3)
+cmake_minimum_required(VERSION 3.12.3)
 
 project(UOX3 CXX C)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.15.3)
+
+project(UOX3 CXX C)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_executable(uox3
+	source/uox3.cpp
+	source/uox3.rc
+)
+
+target_link_libraries(uox3 uox)
+
+add_subdirectory(source)
+add_subdirectory(spidermonkey)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,0 +1,98 @@
+add_library(uox
+	STATIC
+		CGump.cpp
+		boats.cpp
+		cSocket.cpp
+		items.cpp
+		speech.cpp
+		CJSEngine.cpp
+		books.cpp
+		cSpawnRegion.cpp
+		jail.cpp
+		ssection.cpp
+		CJSMapping.cpp
+		cAccountClass.cpp
+		cThreadQueue.cpp
+		lineofsight.cpp
+		targeting.cpp
+		CPacketReceive.cpp
+		cBaseobject.cpp
+		cVersionClass.cpp
+		magic.cpp
+		threadsafeobject.cpp
+		CPacketSend.cpp
+		cChar.cpp
+		cWeather.cpp
+		mapstuff.cpp
+		townregion.cpp
+		CResponse.cpp
+		cConsole.cpp
+		calcfuncs.cpp
+		movement.cpp
+		trade.cpp
+		Dictionary.cpp
+		cDice.cpp
+		cmdtable.cpp
+		msgboard.cpp
+		uox3.cpp
+		JSEncapsulate.cpp
+		cGuild.cpp
+		combat.cpp
+		network.cpp
+		ustring.cpp
+		ODBCManager.cpp
+		cHTMLSystem.cpp
+		commands.cpp
+		npcs.cpp
+		vendor.cpp
+		ObjectFactory.cpp
+		cItem.cpp
+		cplayeraction.cpp
+		pcmanage.cpp
+		weight.cpp
+		PartySystem.cpp
+		cMultiObj.cpp
+		dist.cpp
+		quantityfuncs.cpp
+		wholist.cpp
+		SEFunctions.cpp
+		cPlayerAction.cpp
+		effect.cpp
+		queue.cpp
+		worldmain.cpp
+		UOXJSMethods.cpp
+		cRaces.cpp
+		fileio.cpp
+		regions.cpp
+		UOXJSPropertyFuncs.cpp
+		cScript.cpp
+		findfuncs.cpp
+		scriptc.cpp
+		ai.cpp
+		cServerData.cpp
+		gumps.cpp
+		skills.cpp
+		archive.cpp
+		cServerDefinitions.cpp
+		house.cpp
+		sound.cpp
+)
+
+target_include_directories(uox
+	PUBLIC
+		${PROJECT_SOURCE_DIR}/spidermonkey
+)
+
+target_compile_definitions(uox
+	PRIVATE
+		_CRT_NO_VA_START_VALIDATION
+		$<$<CONFIG:Debug>:_ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH>
+		$<$<PLATFORM_ID:Windows>:EXPORT_JS_API>
+)
+
+target_link_libraries(uox
+	PUBLIC
+		js32
+		$<$<PLATFORM_ID:Windows>:wsock32>
+		$<$<PLATFORM_ID:Windows>:ws2_32>
+)

--- a/spidermonkey/CMakeLists.txt
+++ b/spidermonkey/CMakeLists.txt
@@ -1,0 +1,71 @@
+add_library(js32
+	SHARED
+		jsapi.c
+		jsarena.c
+		jsarray.c
+		jsatom.c
+		jsbool.c
+		jscntxt.c
+		jsdate.c
+		jsdbgapi.c
+		jsdhash.c
+		jsdtoa.c
+		jsemit.c
+		jsexn.c
+		jsfun.c
+		jsgc.c
+		jshash.c
+		jsinterp.c
+		jslock.c
+		jslog2.c
+		jslong.c
+		jsmath.c
+		jsnum.c
+		jsobj.c
+		jsopcode.c
+		jsparse.c
+		jsprf.c
+		jsregexp.c
+		jsscan.c
+		jsscope.c
+		jsscript.c
+		jsstr.c
+		jsutil.c
+		jsxdrapi.c
+		jsxml.c
+		prmjtime.c
+)
+
+target_link_libraries(js32
+	PRIVATE
+		fdlibm
+)
+
+#target_link_options(js32
+#	PRIVATE
+#		$<$<PLATFORM_ID:Windows>:/dll>
+#		$<$<PLATFORM_ID:Windows>:/machine:I386>
+#		$<$<PLATFORM_ID:Windows>:/opt:ref,noicf>
+#		$<$<PLATFORM_ID:Windows>:/subsystem:windows>
+#)
+
+target_compile_definitions(js32
+	PRIVATE
+		_X86_
+		$<$<PLATFORM_ID:Windows>:XP_WIN>
+		$<$<PLATFORM_ID:Windows>:JSFILE>
+		$<$<PLATFORM_ID:Windows>:EXPORT_JS_API>
+)
+
+#target_compile_options(js32
+#	PRIVATE
+#		$<$<C_COMPILER_ID:MSVC>:/W3>
+#		$<$<C_COMPILER_ID:MSVC>:/EHsc>
+#)
+
+set_target_properties(js32
+	PROPERTIES
+         RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}
+)
+
+add_subdirectory(fdlibm)

--- a/spidermonkey/fdlibm/CMakeLists.txt
+++ b/spidermonkey/fdlibm/CMakeLists.txt
@@ -1,0 +1,32 @@
+add_library(fdlibm
+	STATIC
+		e_atan2.c
+		e_pow.c
+		e_sqrt.c
+		k_standard.c
+		s_atan.c
+		s_copysign.c
+		s_fabs.c
+		s_finite.c
+		s_isnan.c
+		s_matherr.c
+		s_rint.c
+		s_scalbn.c
+		w_atan2.c
+		w_pow.c
+		w_sqrt.c
+		s_lib_version.c
+)
+
+target_compile_definitions(fdlibm
+	PRIVATE
+		_X86_
+		$<$<PLATFORM_ID:Windows>:_IEEE_LIBM>
+		$<$<PLATFORM_ID:Windows>:XP_WIN>
+)
+
+#target_compile_options(fdlibm
+#	PRIVATE
+#		$<$<C_COMPILER_ID:MSVC>:/W3>
+#		$<$<C_COMPILER_ID:MSVC>:/EHsc>
+#)


### PR DESCRIPTION
Hi Xuri, can you verify if it works on machine please. These files should build UOX3 in one go, including the working js32.dll. I tested with 32bit release and debug uding both msvc and clang.

If it does not work at your end, please removes the comments to unlock more compiler flags. Otherwise, please remove them before merging.

