### PR TITLE
cmake changes

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -100,6 +100,5 @@ target_link_libraries(uox
 	PUBLIC
 		js32
 		zlibstatic
-		$<$<PLATFORM_ID:Windows>:wsock32>
 		$<$<PLATFORM_ID:Windows>:ws2_32>
 )

--- a/spidermonkey/CMakeLists.txt
+++ b/spidermonkey/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(js32
-	SHARED
+	STATIC
 		jsapi.c
 		jsarena.c
 		jsarray.c
@@ -37,18 +37,7 @@ add_library(js32
 		prmjtime.c
 )
 
-target_link_libraries(js32
-	PRIVATE
-		fdlibm
-)
 
-#target_link_options(js32
-#	PRIVATE
-#		$<$<PLATFORM_ID:Windows>:/dll>
-#		$<$<PLATFORM_ID:Windows>:/machine:I386>
-#		$<$<PLATFORM_ID:Windows>:/opt:ref,noicf>
-#		$<$<PLATFORM_ID:Windows>:/subsystem:windows>
-#)
 
 target_compile_definitions(js32
 	PRIVATE
@@ -58,15 +47,9 @@ target_compile_definitions(js32
 		$<$<PLATFORM_ID:Windows>:EXPORT_JS_API>
 )
 
-#target_compile_options(js32
-#	PRIVATE
-#		$<$<C_COMPILER_ID:MSVC>:/W3>
-#		$<$<C_COMPILER_ID:MSVC>:/EHsc>
-#)
+
 
 set_target_properties(js32
 	PROPERTIES
          RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}
 )
-
-add_subdirectory(fdlibm)


### PR DESCRIPTION
Changed js from shared to static library.  Removed fdlibm from spidermonkey build (only needed if making the executable to do command line js).