### PR TITLE
Uox3 1

### DIFF
--- a/source/CGump.cpp
+++ b/source/CGump.cpp
@@ -7,7 +7,7 @@
 #include "gump.h"
 #include "CPacketSend.h"
 #include <cstdint>
-
+#include <algorithm>
 
 CGump::CGump( bool myNoMove, bool myNoClose )
 {
@@ -47,13 +47,12 @@ void CGump::Send( CSocket *target )
 	toSend.GumpID( Type );
 	toSend.UserID( Serial );
 
-	STRINGLIST_CITERATOR tIter;
-	for( tIter = TagList.begin(); tIter != TagList.end(); ++tIter )
-		toSend.addCommand( (*tIter) );
-
-	for( tIter = TextList.begin(); tIter != TextList.end(); ++tIter )
-		toSend.addText( (*tIter) );
-
+	std::for_each(TagList.begin(),TagList.end(),[&toSend](const std::string& text){
+		toSend.addCommand(text);
+	});
+	std::for_each(TextList.begin(),TextList.end(),[&toSend](const std::string& text){
+		toSend.addCommand(text);
+	});
 	toSend.Finalize();
 	target->Send( &toSend );
 }

--- a/source/CPacketSend.cpp
+++ b/source/CPacketSend.cpp
@@ -4889,7 +4889,7 @@ void CPCharAndStartLoc::NumberOfLocations( UI08 numLocations, CSocket *mSock )
 	pStream.WriteByte( byteOffset, numLocations );
 }
 
-void CPCharAndStartLoc::AddStartLocation( LPSTARTLOCATION sLoc, UI08 locOffset )
+void CPCharAndStartLoc::AddStartLocation( start_location *sLoc, UI08 locOffset )
 {
 	if( sLoc == nullptr )
 		return;
@@ -4903,7 +4903,7 @@ void CPCharAndStartLoc::AddStartLocation( LPSTARTLOCATION sLoc, UI08 locOffset )
 	pStream.WriteString( static_cast<size_t>(baseOffset)+33, sLoc->oldDescription, 31 );
 }
 
-void CPCharAndStartLoc::NewAddStartLocation( LPSTARTLOCATION sLoc, UI08 locOffset )
+void CPCharAndStartLoc::NewAddStartLocation( start_location *sLoc, UI08 locOffset )
 {
 	if( sLoc == nullptr )
 		return;

--- a/source/CPacketSend.cpp
+++ b/source/CPacketSend.cpp
@@ -13,13 +13,17 @@
 #include "Dictionary.h"
 #include "cScript.h"
 #include "CJSMapping.h"
+
 #include <string>
 #include <locale>
 #include <codecvt>
+#include <algorithm>
 #include "osunique.hpp"
 #if defined(_WIN32)
 #include <ws2tcpip.h>
 #endif
+
+using namespace std::string_literals;
 // Unknown bytes
 // 5->8
 // 18->27
@@ -6295,10 +6299,9 @@ void CPBookPage::NewPage( SI16 pNum, const STRINGLIST *lines )
 		pStream.WriteShort( baseOffset, pNum );
 	pStream.WriteByte( static_cast<size_t>(baseOffset + 3), static_cast<UI08>(lines->size()) );	// 8 lines per page
 
-	for( STRINGLIST_CITERATOR lIter = lines->begin(); lIter != lines->end(); ++lIter )
-	{
-		AddLine( (*lIter) );
-	}
+	std::for_each(lines->begin(), lines->end(), [this](const std::string &text){
+		AddLine(text);
+	});
 }
 void CPBookPage::Finalize( void )
 {
@@ -6394,25 +6397,26 @@ void CPSendGumpMenu::Finalize( void )
 	UI32 length		= 21;
 	UI16 increment	= 0;
 	UI16 lineLen	= 0;
-
 	std::string cmdString;
-
-	for( STRINGLIST_CITERATOR cIter = commands.begin(); cIter != commands.end(); ++cIter )
-	{
-		lineLen = static_cast<UI16>((*cIter).length());
-		if( lineLen == 0 )
-			break;
-		increment = static_cast<UI16>(lineLen + 4);
-		if( (length + increment) >= 0xFFFF )
-		{
-			Console.warning( "SendGump Packet (0xB0) attempted to send a packet that exceeds 65355 bytes!" );
+	for (auto &entry:commands){
+		if (!entry.empty()){
+			lineLen = static_cast<UI16>(entry.length());
+			increment = static_cast<UI16>(lineLen + 4);
+			if( (length + increment) >= 0xFFFF )
+			{
+				Console.warning( "SendGump Packet (0xB0) attempted to send a packet that exceeds 65355 bytes!" );
+				break ;
+			}
+			pStream.ReserveSize( static_cast<size_t>(length) + static_cast<size_t>(increment) );
+			cmdString = "{ "s + entry + " }"s;
+			pStream.WriteString( length, cmdString, increment );
+			length	+= increment;
+			
+		}
+		else {
+			lineLen = 0 ;
 			break;
 		}
-
-		pStream.ReserveSize( static_cast<size_t>(length) + static_cast<size_t>(increment) );
-		cmdString = "{ " + (*cIter) + " }";
-		pStream.WriteString( length, cmdString, increment );
-		length	+= increment;
 	}
 
 	if( length > 65536 )
@@ -6426,26 +6430,30 @@ void CPSendGumpMenu::Finalize( void )
 
 	pStream.ReserveSize( length );	// match the 3 byte increase
 
-	for( STRINGLIST_CITERATOR tIter = text.begin(); tIter != text.end(); ++tIter )
-	{
-		lineLen = static_cast<UI16>((*tIter).length());
-		if( lineLen == 0 )
-			break;
-		// Unfortunately, unicode strings are... different
-		// so we can't use PackString
-		increment	= lineLen * 2 + 2;
-		if( (length + increment) >= 0xFFFF )
-		{
-			Console.warning( "SendGump Packet (0xB0) attempted to send a packet that exceeds 65355 bytes!" );
+	for (auto &entry:text){
+		if (!entry.empty()){
+			lineLen = static_cast<UI16>(entry.length());
+			// Unfortunately, unicode strings are... different
+			// so we can't use PackString
+			increment	= lineLen * 2 + 2;
+			if( (length + increment) >= 0xFFFF )
+			{
+				Console.warning( "SendGump Packet (0xB0) attempted to send a packet that exceeds 65355 bytes!" );
+				break;
+			}
+
+			pStream.ReserveSize( static_cast<size_t>(length) + static_cast<size_t>(increment) );
+			pStream.WriteShort( length, lineLen );
+			for( UI16 i = 0; i < lineLen; ++i ){
+				pStream.WriteByte( static_cast<size_t>(length) + 3 + static_cast<size_t>(i)*2, entry[i] );
+			}
+			length += increment;
+			++tlines;
+		}
+		else {
+			lineLen = 0 ;
 			break;
 		}
-
-		pStream.ReserveSize( static_cast<size_t>(length) + static_cast<size_t>(increment) );
-		pStream.WriteShort( length, lineLen );
-		for( UI16 i = 0; i < lineLen; ++i )
-			pStream.WriteByte( static_cast<size_t>(length) + 3 + static_cast<size_t>(i)*2, (*tIter)[i] );
-		length += increment;
-		++tlines;
 	}
 
 	if( length > 65536 )

--- a/source/CPacketSend.cpp
+++ b/source/CPacketSend.cpp
@@ -6288,7 +6288,7 @@ void CPBookPage::AddLine( const std::string& line )
 	IncLength( static_cast< UI08 >(strLen) );
 	pStream.WriteString( baseOffset, line, line.length() );
 }
-void CPBookPage::NewPage( SI16 pNum, const STRINGLIST *lines )
+void CPBookPage::NewPage( SI16 pNum, const std::vector<std::string> *lines )
 {
 	++pageCount;	// 1 based counter
 	UI16 baseOffset = bookLength;

--- a/source/CPacketSend.h
+++ b/source/CPacketSend.h
@@ -1280,7 +1280,7 @@ public:
 	void			Object( CItem& obj );
 	void			Serial( SERIAL value );
 	void			NewPage( SI16 pNum = -1 );
-	void			NewPage( SI16 pNum, const STRINGLIST *lines );
+	void			NewPage( SI16 pNum, const std::vector<std::string> *lines );
 	void			AddLine( const std::string& line );
 	void			Finalize( void );
 };
@@ -1288,7 +1288,7 @@ public:
 class CPSendGumpMenu : public CPUOXBuffer
 {
 protected:
-	STRINGLIST		commands, text;
+	std::vector<std::string>		commands, text;
 public:
 	virtual			~CPSendGumpMenu()
 	{

--- a/source/CPacketSend.h
+++ b/source/CPacketSend.h
@@ -977,8 +977,8 @@ public:
 	CPCharAndStartLoc( CAccountBlock& account, UI08 numCharacters, UI08 numLocations, CSocket *mSock );
 	virtual void	NumberOfLocations( UI08 numLocations, CSocket *mSock );
 	virtual void	AddCharacter( CChar *toAdd, UI08 charOffset );
-	virtual void	AddStartLocation( LPSTARTLOCATION sLoc, UI08 locOffset  );
-	virtual void	NewAddStartLocation( LPSTARTLOCATION sLoc, UI08 locOffset );
+	virtual void	AddStartLocation( start_location *sLoc, UI08 locOffset  );
+	virtual void	NewAddStartLocation( start_location *sLoc, UI08 locOffset );
 	CPCharAndStartLoc& operator=( CAccountBlock& actbBlock );
 	virtual void	Log( std::ofstream &outStream, bool fullHeader = true ) override;
 };

--- a/source/CResponse.cpp
+++ b/source/CResponse.cpp
@@ -56,23 +56,21 @@ inline bool findString( std::string toCheck, std::string toFind )
 CHARLIST findNearbyNPCs( CChar *mChar, distLocs distance )
 {
 	CHARLIST ourNpcs;
-	REGIONLIST nearbyRegions = MapRegion->PopulateList( mChar );
-	for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
+	auto nearbyRegions = MapRegion->PopulateList( mChar );
+	for( auto &CellResponse : nearbyRegions)
 	{
-		CMapRegion *CellResponse = (*rIter);
-		if( CellResponse == nullptr )
-			continue;
-
-		GenericList< CChar * > *regChars = CellResponse->GetCharList();
-		regChars->Push();
-		for( CChar *Npc = regChars->First(); !regChars->Finished(); Npc = regChars->Next() )
-		{
-			if( !ValidateObject( Npc ) || Npc == mChar || !Npc->IsNpc() || Npc->GetInstanceID() != mChar->GetInstanceID() )
-				continue;
-			if( objInRange( mChar, Npc, distance ) )
-				ourNpcs.push_back( Npc );
+		if (CellResponse != nullptr){
+			GenericList< CChar * > *regChars = CellResponse->GetCharList();
+			regChars->Push();
+			for( CChar *Npc = regChars->First(); !regChars->Finished(); Npc = regChars->Next() )
+			{
+				if( !ValidateObject( Npc ) || Npc == mChar || !Npc->IsNpc() || Npc->GetInstanceID() != mChar->GetInstanceID() )
+					continue;
+				if( objInRange( mChar, Npc, distance ) )
+					ourNpcs.push_back( Npc );
+			}
+			regChars->Pop();
 		}
-		regChars->Pop();
 	}
 	return ourNpcs;
 }

--- a/source/ObjectFactory.cpp
+++ b/source/ObjectFactory.cpp
@@ -5,7 +5,11 @@
 #include <algorithm>
 #include <climits>
 
-#include "uox3.h"
+#include "cBaseObject.h"
+#include "cItem.h" // Includes CItem, CSpawnItem
+#include "cMultiObj.h" // Includes CMultiObj, CBoatObj
+#include "cChar.h" // Includes CChar
+
 
 //=========================================================
 // serialgen_t

--- a/source/ObjectFactory.cpp
+++ b/source/ObjectFactory.cpp
@@ -1,414 +1,309 @@
+
 #include "ObjectFactory.h"
+
+#include <iostream>
+#include <algorithm>
+#include <climits>
+
 #include "uox3.h"
-#include <mutex>
 
-#define HASHMAX 2477 // hashmax must be a prime for maximum performce.
-
-inline SERIAL HashSerial( SERIAL toHash )
-{
-	return toHash%HASHMAX;
+//=========================================================
+// serialgen_t
+//=========================================================
+//=========================================================
+serialgen_t::serialgen_t(std::uint32_t initial) :serial_number(initial){
+	
+}
+//=========================================================
+auto serialgen_t::next() -> std::uint32_t {
+	return serial_number++;
+}
+//=========================================================
+auto serialgen_t::registerSerial(std::uint32_t serial) ->void {
+	if (serial >= serial_number) {
+		serial_number = serial + 1 ;
+	}
+}
+//=========================================================
+auto serialgen_t::unregisterSerial(std::uint32_t serial) ->void {
+	if (serial_number == (serial+1)){
+		serial_number = serial ;
+	}
 }
 
-/** This class is responsible for the creation and destruction of ingame
- objects and should mean that we can take chars[] and items[] out of scope
- */
+//=========================================================
+auto serialgen_t::operator=(std::uint32_t value) ->serialgen_t& {
+	serial_number = value ;
+	return *this;
+}
+//=========================================================
+auto serialgen_t::operator=(std::int32_t value) ->serialgen_t& {
+	serial_number = static_cast<std::uint32_t>(value) ;
+	return *this;
+}
 
-//o-----------------------------------------------------------------------------------------------o
-
-ObjectFactory& ObjectFactory::getSingleton( void )
-{
-	std::mutex lock;
-	std::scoped_lock scope(lock) ;
+//=========================================================
+// ObjectFactory
+//=========================================================
+//=========================================================
+ObjectFactory::ObjectFactory(){
+	
+}
+//=========================================================
+auto ObjectFactory::getSingleton() -> ObjectFactory& {
 	static ObjectFactory instance ;
 	return instance ;
 }
-//o-----------------------------------------------------------------------------------------------o
-
-// Starting Characters with a serial of 1, rather than 0. The UO Client doesn't always respond well to a serial of 0 -   6/21/08
-ObjectFactory::ObjectFactory() : nextPC( 1 ), nextNPC( 1 ), nextItem( BASEITEMSERIAL ), nextMulti( BASEITEMSERIAL )
-{
-}
-ObjectFactory::~ObjectFactory()
-{
-	chars.clear();
-	multis.clear();
-	items.clear();
-}
-
-//o-----------------------------------------------------------------------------------------------o
-//|	Function	-	size_t SizeOfObjects( ObjectType toCount )
-//o-----------------------------------------------------------------------------------------------o
-//|	Purpose		-	Returns the size of memory allocated to given object type
-//o-----------------------------------------------------------------------------------------------o
-size_t ObjectFactory::SizeOfObjects( ObjectType toCount )
-{
-	size_t toRet = 0;
-	switch( toCount )
-	{
-		default:
-			break;
-		case OT_ITEM:
-		case OT_SPAWNER:
-			toRet = items.size() * sizeof( CItem );
-			break;
-		case OT_MULTI:
-		case OT_BOAT:
-			toRet = multis.size() * sizeof( CMultiObj );
-			break;
-		case OT_CHAR:
-			toRet = chars.size() * sizeof( CChar );
-			break;
-	}
-	return toRet;
-}
-
-//o-----------------------------------------------------------------------------------------------o
-//|	Function	-	size_t CountOfObjects( ObjectType toCount )
-//o-----------------------------------------------------------------------------------------------o
-//|	Purpose		-	Returns the amount of objects that exist of a given object type
-//o-----------------------------------------------------------------------------------------------o
-UI32 ObjectFactory::CountOfObjects( ObjectType toCount )
-{
-	UI32 toRet = 0;
-	switch( toCount )
-	{
-		default:
-			break;
-		case OT_ITEM:
-		case OT_SPAWNER:
-			toRet = static_cast<UI32>(items.size());
-			break;
-		case OT_MULTI:
-		case OT_BOAT:
-			toRet = static_cast<UI32>(multis.size());
-			break;
-		case OT_CHAR:
-			toRet = static_cast<UI32>(chars.size());
-			break;
-	}
-	return toRet;
-}
-
-//o-----------------------------------------------------------------------------------------------o
-//|	Function	-	SERIAL ObjectFactory::NextFreeSerial( ObjectType toFind )
-//o-----------------------------------------------------------------------------------------------o
-//|	Purpose		-	Finds the next free serial to use when creating an object of a given type
-//|
-//|	Notes		-	Later on we will track in depth, but this allows us
-//|					to keep an eye on the serials in use, and make sure
-//|					that we assign them correctly
-//|
-//|					For the moment, we'll keep items and chars under a simple system, though
-//|					long term we probably want to break it out
-//o-----------------------------------------------------------------------------------------------o
-SERIAL ObjectFactory::NextFreeSerial( ObjectType toFind )
-{
-	SERIAL toRet = INVALIDSERIAL;
-	switch( toFind )
-	{
-		default:
-			break;
+//=========================================================
+auto ObjectFactory::nextSerial(ObjectType type) -> std::uint32_t {
+	switch (type){
 		case OT_ITEM:
 		case OT_MULTI:
 		case OT_BOAT:
 		case OT_SPAWNER:
-			toRet = nextItem++;
+			return item_serials.next();
+		case OT_CHAR:
+			return character_serials.next();
+		default:
+			return std::numeric_limits<std::uint32_t>::max();
+	}
+}
+//=========================================================
+auto ObjectFactory::findCharacter(std::uint32_t serial) ->CBaseObject*{
+	auto iter = chars.find(serial) ;
+	if (iter != chars.end()){
+		return iter->second;
+	}
+	return nullptr ;
+}
+//=========================================================
+auto ObjectFactory::collectionForType(ObjectType type) -> factory_collection* {
+	factory_collection *collection = nullptr ;
+	switch (type) {
+		case OT_MULTI:
+		case OT_BOAT:
+			collection = &multis;
+			break;
+		case OT_SPAWNER:
+		case OT_ITEM:
+			collection = &items;
 			break;
 		case OT_CHAR:
-			toRet = nextNPC++;
+			collection = &chars;
+			break;
+			
+		default:
 			break;
 	}
-	return toRet;
+	return collection ;
+	
 }
-
-//o-----------------------------------------------------------------------------------------------o
-//|	Function	-	CBaseObject *CreateObject( ObjectType createType )
-//o-----------------------------------------------------------------------------------------------o
-//|	Purpose		-	Create a new object with a serial number, and return it back to the creator
-//|					From DFNs, or a PC, by and large.
-//o-----------------------------------------------------------------------------------------------o
-CBaseObject *ObjectFactory::CreateObject( ObjectType createType )
-{
-	CBaseObject *created = nullptr;
-	switch( createType )
-	{
-		default:													break;
-		case OT_ITEM:			created	= new CItem();				break;
-		case OT_MULTI:			created	= new CMultiObj();			break;
-		case OT_BOAT:			created	= new CBoatObj();			break;
-		case OT_SPAWNER:		created	= new CSpawnItem();			break;
-		case OT_CHAR:			created	= new CChar();				break;
+//=========================================================
+auto ObjectFactory::collectionForType(ObjectType type) const -> const factory_collection* {
+	const factory_collection *collection = nullptr ;
+	switch (type) {
+		case OT_MULTI:
+		case OT_BOAT:
+			collection = &multis;
+			break;
+		case OT_SPAWNER:
+		case OT_ITEM:
+			collection = &items;
+			break;
+		case OT_CHAR:
+			collection = &chars;
+			break;
+			
+		default:
+			break;
 	}
-	// assign serial here
-	if( created != nullptr )
-		created->SetSerial( NextFreeSerial( createType ) );	// SetSerial() will register our object -
-
-	return created;
+	return collection ;
+	
 }
 
-//o-----------------------------------------------------------------------------------------------o
-//|	Function	-	CBaseObject *CreateBlankObject( ObjectType createType )
-//o-----------------------------------------------------------------------------------------------o
-//|	Purpose		-	Create a new blank object without a serial number. Serial will be provided
-//|					when loading object from worldfiles
-//o-----------------------------------------------------------------------------------------------o
-CBaseObject *ObjectFactory::CreateBlankObject( ObjectType createType )
-{
-	CBaseObject *created = nullptr;
-	switch( createType )
-	{
-		default:													break;
-		case OT_ITEM:			created	= new CItem();				break;
-		case OT_MULTI:			created	= new CMultiObj();			break;
-		case OT_BOAT:			created	= new CBoatObj();			break;
-		case OT_SPAWNER:		created	= new CSpawnItem();			break;
-		case OT_CHAR:			created	= new CChar();				break;
+//=========================================================
+auto ObjectFactory::findItem(std::uint32_t serial) ->CBaseObject*{
+	// We look for items first
+	CBaseObject *object = nullptr ;
+	auto iter = items.find(serial) ;
+	if (iter != items.end()){
+		object = iter->second;
 	}
-	return created;
+	else {
+		iter = multis.find(serial);
+		if (iter!= multis.end()){
+			object = iter->second ;
+		}
+	}
+	return object ;
 }
 
-//o-----------------------------------------------------------------------------------------------o
-//|	Function	-	CBaseObject *FindObject( SERIAL toFind )
-//o-----------------------------------------------------------------------------------------------o
-//|	Purpose		-	Calculate item, multi or character object from provided serial
-//o-----------------------------------------------------------------------------------------------o
-CBaseObject *ObjectFactory::FindObject( SERIAL toFind )
-{
-	OBJECTMAP_ITERATOR fIter, fUpper, fEnd;
-	CBaseObject	*	retVal		= nullptr;
-	SERIAL			hashValue	= HashSerial( toFind );
-	if( toFind != INVALIDSERIAL )
-	{
-		if( toFind >= BASEITEMSERIAL )	// either an item or multi
-		{
-			fIter	= items.find( hashValue );
-			fUpper	= items.upper_bound( hashValue );
-			fEnd	= items.end();
-			while( fIter != fUpper && fIter != fEnd )
-			{
-				if( fIter->second->GetSerial() == toFind )	// is this our object?
-				{
-					retVal = fIter->second;
-					break;
-				}
-				else
-					++fIter;
+//=========================================================
+auto ObjectFactory::removeObject(std::uint32_t serial,factory_collection &collection)->bool{
+	auto rvalue = false ;
+	auto iter = collection.find(serial) ;
+	if (iter != collection.end()){
+		rvalue = true ;
+		collection.erase(iter);
+	}
+	return rvalue ;
+}
+
+//=========================================================
+auto ObjectFactory::RegisterObject( CBaseObject *object) ->bool {
+	auto rvalue = false ;
+	if (object) {
+		rvalue = this->RegisterObject(object, object->GetSerial());
+	}
+	return rvalue ;
+}
+//=========================================================
+auto ObjectFactory::RegisterObject( CBaseObject *object, std::uint32_t serial) ->bool {
+	auto rvalue = false ;
+	if (object){
+		switch (object->GetObjType()) {
+			case OT_MULTI:
+			case OT_BOAT:
+				rvalue = true ;
+				item_serials.registerSerial(serial);
+				multis.insert_or_assign(serial, object);
+				break;
+			case OT_SPAWNER:
+			case OT_ITEM:
+				rvalue = true ;
+				item_serials.registerSerial(serial);
+				items.insert_or_assign(serial, object);
+				break;
+			case OT_CHAR:
+				rvalue = true ;
+				character_serials.registerSerial(serial);
+				chars.insert_or_assign(serial, object);
+				break;
+				
+			default:
+				break;
+		}
+	}
+	return rvalue ;
+}
+//=========================================================
+auto ObjectFactory::UnregisterObject(CBaseObject *object) ->bool {
+	auto rvalue = false ;
+	if (object) {
+		switch (object->GetObjType()){
+			case OT_MULTI:
+			case OT_BOAT:
+				rvalue = removeObject(object->GetObjType(), multis);
+				break;
+			case OT_ITEM:
+			case OT_SPAWNER:
+				rvalue = removeObject(object->GetObjType(), items);
+				break;
+			case OT_CHAR:
+				rvalue = removeObject(object->GetObjType(), chars);
+				break;
+			default:
+				break;
+		}
+	}
+	return rvalue ;
+}
+//=========================================================
+auto ObjectFactory::IterateOver(ObjectType type, std::uint32_t &b, void *extra, std::function<bool(CBaseObject*,std::uint32_t &,void *)> function) ->std::uint32_t{
+	auto collection = collectionForType(type) ;
+	if (collection) {
+		auto cont = true ;
+		std::for_each(collection->begin(), collection->end(), [&cont, &b,&extra,&function](std::pair<std::uint32_t, CBaseObject*> entry){
+			if (cont){
+				cont = function(entry.second,b,extra);
 			}
-			if( retVal == nullptr )	// Not an item!  Let's check multis
-			{
-				fIter	= multis.find( hashValue );
-				fUpper	= multis.upper_bound( hashValue );
-				fEnd	= multis.end();
-				while( fIter != fUpper && fIter != fEnd )
-				{
-					if( fIter->second->GetSerial() == toFind )	// is this our object?
-					{
-						retVal = fIter->second;
-						break;
-					}
-					else
-						++fIter;
-				}
-			}
-		}
-		else	// a character of some sort
-		{
-			fIter	= chars.find( hashValue );
-			fUpper	= chars.upper_bound( hashValue );
-			fEnd	= chars.end();
-			while( fIter != fUpper && fIter != fEnd )
-			{
-				if( fIter->second->GetSerial() == toFind )	// is this our object?
-				{
-					retVal = fIter->second;
-					break;
-				}
-				else
-					++fIter;
-			}
-		}
+		});
+		
 	}
-	return retVal;
+	return 0 ;
+}
+//=========================================================
+auto ObjectFactory::DestroyObject(CBaseObject *object) ->bool {
+	auto rvalue = false ;
+	if (object){
+		UnregisterObject(object);
+		delete object ; // pointers are passed by value, so no need to then set to nullptr
+		rvalue = true ;
+	}
+	return rvalue ;
 }
 
-//o-----------------------------------------------------------------------------------------------o
-//|	Function	-	bool DestroyObject( CBaseObject *toDestroy )
-//o-----------------------------------------------------------------------------------------------o
-//|	Purpose		-	This function unregisters the object and destroys it from memory.
-//|					Essentially, it's either a server shutdown or the object has been deleted,
-//|					and is no longer part of the world.
-//o-----------------------------------------------------------------------------------------------o
-bool ObjectFactory::DestroyObject( CBaseObject *toDestroy )
-{
-	assert( toDestroy != nullptr );
-	UnregisterObject( toDestroy );
-	delete toDestroy;
-	toDestroy = nullptr;
-	return true;
+//=========================================================
+auto ObjectFactory::CreateObject(ObjectType type) -> CBaseObject * {
+	auto object = CreateBlankObject(type);
+	if (object) {
+		object->SetSerial(nextSerial(type));
+	}
+	return object;
 }
-
-//o-----------------------------------------------------------------------------------------------o
-//|	Function	-	bool RegisterObject( CBaseObject *toRegister )
-//o-----------------------------------------------------------------------------------------------o
-//|	Purpose		-	We want to register an object with the world, that previously
-//|					does not exist in our containers
-//o-----------------------------------------------------------------------------------------------o
-bool ObjectFactory::RegisterObject( CBaseObject *toRegister )
-{
-	assert( toRegister != nullptr );
-	return RegisterObject( toRegister, toRegister->GetSerial() );
-}
-
-//o-----------------------------------------------------------------------------------------------o
-//|	Function	-	bool RegisterObject( CBaseObject *toRegister, SERIAL toAttach )
-//o-----------------------------------------------------------------------------------------------o
-//|	Purpose		-	This allows us to register our object with it's attached serial number
-//|
-//|					Note that we do not check if this object existed previously, so if you
-//|					want to change an object's serial, you would have to Unregister it
-//|					and then Register it with the new serial. HOWEVER, that does not guarantee
-//|					valid serial numbers and that it's not a duplicate! By and large, we don't
-//|					want to call this from anywhere but a world loading routine.
-//o-----------------------------------------------------------------------------------------------o
-bool ObjectFactory::RegisterObject( CBaseObject *toRegister, SERIAL toAttach )
-{
-	assert( toRegister != nullptr );
-	ObjectType reg = toRegister->GetObjType();
-	switch( reg )
-	{
+//=========================================================
+auto ObjectFactory::CreateBlankObject(ObjectType type) ->CBaseObject * {
+	CBaseObject *object = nullptr ;
+	switch(type) {
+		case OT_ITEM:
+			object = new CItem() ;
+			break;
+		case OT_MULTI:
+			object = new CMultiObj() ;
+			break;
+		case OT_BOAT:
+			object = new CBoatObj() ;
+			break;
+		case OT_SPAWNER:
+			object = new CSpawnItem() ;
+			break;
+		case OT_CHAR:
+			object = new CChar() ;
+			break;
 		default:
+			break;
+	}
+	return object ;
+}
+//=========================================================
+auto ObjectFactory::FindObject( std::uint32_t serial ) -> CBaseObject * {
+	CBaseObject *object = nullptr ;
+	if (serial >= BASEITEMSERIAL) {
+		object = findItem(serial);
+	}
+	else {
+		object = findCharacter(serial);
+	}
+	return object ;
+}
+//=========================================================
+auto ObjectFactory::CountOfObjects(ObjectType type) const -> std::uint32_t {
+	auto rvalue = std::uint32_t(0) ;
+	auto collection = collectionForType(type);
+	if (collection){
+		rvalue = static_cast<std::uint32_t>(collection->size());
+	}
+	return rvalue ;
+}
+//=========================================================
+auto ObjectFactory::SizeOfObjects(ObjectType type) const ->size_t {
+	auto collection = collectionForType(type);
+	auto size = size_t(0) ;
+	switch (type) {
+		case OT_ITEM:
+		case OT_SPAWNER:
+			size = sizeof( CItem );
 			break;
 		case OT_MULTI:
 		case OT_BOAT:
-			if( toAttach >= nextItem )
-				nextItem = toAttach + 1;
-			multis.insert( std::make_pair( HashSerial( toAttach ), toRegister ) );
-			break;
-		case OT_ITEM:
-		case OT_SPAWNER:
-			if( toAttach >= nextItem )
-				nextItem = toAttach + 1;
-			items.insert( std::make_pair( HashSerial( toAttach ), toRegister ) );
+			size =  sizeof( CMultiObj );
 			break;
 		case OT_CHAR:
-			if( toAttach >= nextNPC )
-				nextNPC = toAttach + 1;
-			chars.insert( std::make_pair( HashSerial( toAttach ), toRegister ) );
-			break;
-	}
-	return true;
-}
-
-//o-----------------------------------------------------------------------------------------------o
-//|	Function	-	bool UnregisterObject( CBaseObject *toRemove )
-//o-----------------------------------------------------------------------------------------------o
-//|	Purpose		-	We're done with an object, or want to detach it from the world
-//|					This function allows us to detach it, but not destroy it
-//|					in case we want to attach it elsewise
-//o-----------------------------------------------------------------------------------------------o
-bool ObjectFactory::UnregisterObject( CBaseObject *toRemove )
-{
-	assert( toRemove != nullptr );
-	OBJECTMAP_ITERATOR rIter, rUpper, rEnd;
-	SERIAL hashValue = HashSerial( toRemove->GetSerial() );
-	switch( toRemove->GetObjType() )
-	{
-		default:
-			throw new std::runtime_error( "Damn, bad bad work here!" );
-			break;
-		case OT_MULTI:
-		case OT_BOAT:
-			rIter	= multis.find( hashValue );
-			rUpper	= multis.upper_bound( hashValue );
-			rEnd	= multis.end();
-			break;
-		case OT_ITEM:
-		case OT_SPAWNER:
-			rIter	= items.find( hashValue );
-			rUpper	= items.upper_bound( hashValue );
-			rEnd	= items.end();
-			break;
-		case OT_CHAR:
-			rIter	= chars.find( hashValue );
-			rUpper	= chars.upper_bound( hashValue );
-			rEnd	= chars.end();
-			break;
-	}
-	while( rIter != rUpper && rIter != rEnd )
-	{
-		if( rIter->second == toRemove )	// is this our object?
-		{
-			// let's remove it from the hash table
-			switch( toRemove->GetObjType() )
-			{
-				case OT_MULTI:
-				case OT_BOAT:		multis.erase( rIter );	break;
-				case OT_ITEM:
-				case OT_SPAWNER:	items.erase( rIter );	break;
-				case OT_CHAR:		chars.erase( rIter );	break;
-				default:
-					break;
-			}
-			break;
-		}
-		else
-			++rIter;
-	}
-	return true;
-}
-
-
-//o-----------------------------------------------------------------------------------------------o
-//|	Function	-	void GarbageCollect( void )
-//o-----------------------------------------------------------------------------------------------o
-//|	Purpose		-	This is to deal with dead or weird objects, but I don't think
-//|					that we would really need it.  No object should be destroyed
-//|					except by this object factory anyway.  We may want to do lazy
-//|					deletes and only do invalidations.
-//o-----------------------------------------------------------------------------------------------o
-void ObjectFactory::GarbageCollect( void )
-{
-	// We may not even need to do anything here, really
-}
-
-//o-----------------------------------------------------------------------------------------------o
-//|	Function	-	UI32 IterateOver( ObjectType toIterOver, UI32 &b, void *extraData, OBJFUNCTOR( text ) )
-//o-----------------------------------------------------------------------------------------------o
-//|	Purpose		-	Iterate over all objects of a specified object type
-//o-----------------------------------------------------------------------------------------------o
-UI32 ObjectFactory::IterateOver( ObjectType toIterOver, UI32 &b, void *extraData, OBJFUNCTOR( text ) )
-{
-	OBJECTMAP_ITERATOR mBegin, mEnd;
-	switch( toIterOver )
-	{
-		case OT_MULTI:
-		case OT_BOAT:
-		{
-			mBegin	= multis.begin();
-			mEnd	= multis.end();
-		}
-			break;
-		case OT_ITEM:
-		case OT_SPAWNER:
-		{
-			mBegin	= items.begin();
-			mEnd	= items.end();
-		}
-			break;
-		case OT_CHAR:
-		{
-			mBegin	= chars.begin();
-			mEnd	= chars.end();
-		}
+			size =   sizeof( CChar );
 			break;
 		default:
-			return 0xFFFFFFFF;
+			break;
 	}
-	bool stillContinue = true;
-	while( mBegin != mEnd && stillContinue )
-	{
-		stillContinue = (*text)(mBegin->second, b, extraData );
-		++mBegin;
-	}
-	return 0;
+	return collection->size() * size ;
+	
 }

--- a/source/ObjectFactory.cpp
+++ b/source/ObjectFactory.cpp
@@ -50,7 +50,7 @@ auto serialgen_t::operator=(std::int32_t value) ->serialgen_t& {
 // ObjectFactory
 //=========================================================
 //=========================================================
-ObjectFactory::ObjectFactory(){
+ObjectFactory::ObjectFactory():character_serials(1),item_serials(BASEITEMSERIAL){
 	
 }
 //=========================================================

--- a/source/ObjectFactory.h
+++ b/source/ObjectFactory.h
@@ -12,21 +12,7 @@
 #include "Prerequisites.h"
 #include "typedefs.h"
 using factory_collection = std::unordered_map<std::uint32_t, CBaseObject*>;
-//=========================================================
-// serialgen_t
-//=========================================================
-//=========================================================
-struct serialgen_t {
-	std::uint32_t serial_number ;
-	serialgen_t(std::uint32_t initial=0) ;
-	auto next() -> std::uint32_t ;
-	auto registerSerial(std::uint32_t serial) ->void ;
-	// Note, this only frees up the serial number if
-	// deregisterd one was the last one created
-	auto unregisterSerial(std::uint32_t serial) ->void ;
-	auto operator=(std::uint32_t value) ->serialgen_t& ;
-	auto operator=(std::int32_t value) ->serialgen_t& ;
-};
+
 //=========================================================
 // ObjectFactory
 //=========================================================
@@ -37,12 +23,27 @@ class ObjectFactory {
 	factory_collection multis;
 	factory_collection items;
 	
-	
+	//=========================================================
+	// serialgen_t
+	//=========================================================
+	// Is is nested as we dont want to pollute the global namespace
+	//=========================================================
+	struct serialgen_t {
+		std::uint32_t serial_number ;
+		serialgen_t(std::uint32_t initial=0) ;
+		auto next() -> std::uint32_t ;
+		auto registerSerial(std::uint32_t serial) ->void ;
+		// Note, this only frees up the serial number if
+		// deregisterd one was the last one created
+		auto unregisterSerial(std::uint32_t serial) ->void ;
+		auto operator=(std::uint32_t value) ->serialgen_t& ;
+		auto operator=(std::int32_t value) ->serialgen_t& ;
+	};
 	serialgen_t item_serials ;
 	serialgen_t character_serials ;
 	
 	auto nextSerial(ObjectType type) -> std::uint32_t ;
-	auto removeObject(std::uint32_t serial,factory_collection &collection)->bool;
+	auto removeObject(std::uint32_t serial,factory_collection *collection)->bool;
 	ObjectFactory() ;
 	
 	auto findCharacter(std::uint32_t serial) ->CBaseObject*;

--- a/source/ObjectFactory.h
+++ b/source/ObjectFactory.h
@@ -1,51 +1,99 @@
-#ifndef __OBJECTFACTORY_H__
-#define __OBJECTFACTORY_H__
+
+#ifndef ObjectFactory_hpp
+#define ObjectFactory_hpp
+
+#include <cstdint>
+#include <unordered_map>
+#include <functional>
 
 #include "Prerequisites.h"
 #include "typedefs.h"
-/** This class is responsible for the creation and destruction of ingame
-	objects and should mean that we can take chars[] and items[] out of scope
- */
-#define OBJFUNCTOR( text )		bool (*text)( CBaseObject *, UI32 &, void * )
-
-class ObjectFactory
-{
-private:
-	typedef std::multimap< SERIAL, CBaseObject *>	OBJECTMAP;
-	typedef OBJECTMAP::iterator						OBJECTMAP_ITERATOR;
-	typedef OBJECTMAP::const_iterator				OBJECTMAP_CITERATOR;
-
-	OBJECTMAP		chars;				// This will split into PCs and NPCs when the object tree expands
-	OBJECTMAP		multis;
-	OBJECTMAP		items;
-	SERIAL			nextPC, nextNPC, nextItem, nextMulti;
-
-	SERIAL			NextFreeSerial( ObjectType toFind );
-	// To be a singleton, we make the constructor
-	// private, and delete the copy/move constructors
-	ObjectFactory();
-	~ObjectFactory();
-	ObjectFactory(const ObjectFactory&) = delete ;
-	ObjectFactory& operator=(const ObjectFactory&) = delete ;
+using factory_collection = std::unordered_map<std::uint32_t, CBaseObject*>;
+//=========================================================
+// serialgen_t
+//=========================================================
+//=========================================================
+struct serialgen_t {
+	std::uint32_t serial_number ;
+	serialgen_t(std::uint32_t initial=0) ;
+	auto next() -> std::uint32_t ;
+	auto registerSerial(std::uint32_t serial) ->void ;
+	// Note, this only frees up the serial number if
+	// deregisterd one was the last one created
+	auto unregisterSerial(std::uint32_t serial) ->void ;
+	auto operator=(std::uint32_t value) ->serialgen_t& ;
+	auto operator=(std::int32_t value) ->serialgen_t& ;
+};
+//=========================================================
+// ObjectFactory
+//=========================================================
+//=========================================================
+//=========================================================
+class ObjectFactory {
+	factory_collection chars;
+	factory_collection multis;
+	factory_collection items;
+	
+	
+	serialgen_t item_serials ;
+	serialgen_t character_serials ;
+	
+	auto nextSerial(ObjectType type) -> std::uint32_t ;
+	auto removeObject(std::uint32_t serial,factory_collection &collection)->bool;
+	ObjectFactory() ;
+	
+	auto findCharacter(std::uint32_t serial) ->CBaseObject*;
+	auto findItem(std::uint32_t serial) ->CBaseObject*;
+	auto collectionForType(ObjectType type) -> factory_collection* ;
+	auto collectionForType(ObjectType type) const -> const factory_collection* ;
 public:
-
-	UI32			CountOfObjects( ObjectType toCount );
-	size_t			SizeOfObjects( ObjectType toCount );
-	CBaseObject *	CreateObject( ObjectType createType );
-	CBaseObject *	CreateBlankObject( ObjectType createType );
-	CBaseObject *	FindObject( SERIAL toFind );
-	bool			DestroyObject( CBaseObject *toDestroy );
-	bool			RegisterObject( CBaseObject *toRegister );
-	bool			RegisterObject( CBaseObject *toRegister, SERIAL toAttach );
-	bool			UnregisterObject( CBaseObject *toRemove );
-	void			GarbageCollect( void );
-
-	UI32			IterateOver( ObjectType toIterOver, UI32 &b, void *extraData, OBJFUNCTOR( text ) );
-
-	// the way you get the instance
-	static ObjectFactory& getSingleton( void );
-
+	ObjectFactory(const ObjectFactory&) = delete ; // remove copy constructor
+	ObjectFactory(const ObjectFactory&& ) = delete ; // remove move constructor
+	auto operator=(const ObjectFactory&) ->ObjectFactory& = delete ; // remove assignment
+	auto operator=(const ObjectFactory&&) ->ObjectFactory& = delete ;// remove move
+	static auto getSingleton() -> ObjectFactory& ;
+	
+	// ********************************************************
+	// The registeration is only setting the serial generation
+	// for the object type to the correct value.  To enusre
+	// an object doesnt have a serial number that is greater
+	// then the next we would generate.  This is used
+	// in world loads, where the serial number is supplied
+	// ********************************************************
+	auto RegisterObject(CBaseObject *object) ->bool ;
+	auto RegisterObject(CBaseObject *object, std::uint32_t serial) ->bool ;
+	
+	// *******************************************************
+	// This removes an object from the collection.  Note, however
+	// that the serial number is not decremented
+	auto UnregisterObject(CBaseObject *object) ->bool ;
+	
+	
+	// *******************************************************
+	// This DOES NOTHING,so please remove the reference call
+	// in uox.cpp, around line 2138
+	auto GarbageCollect() ->void {};
+	
+	// *******************************************************
+	// Iterate over objects
+	auto IterateOver(ObjectType type, std::uint32_t &b, void *extra, std::function<bool(CBaseObject*,std::uint32_t &,void *)> function) ->std::uint32_t;
+	
+	// ******************************************************
+	// This removes the object from the collection, and deletes the object
+	auto DestroyObject(CBaseObject *object) ->bool ;
+	
+	// *******************************************************
+	// Create objects, Blank object doesn't get a serial number
+	auto CreateObject(ObjectType type) -> CBaseObject * ;
+	auto CreateBlankObject(ObjectType type) ->CBaseObject * ;
+	
+	auto FindObject( std::uint32_t toFind ) -> CBaseObject * ;
+	
+	// ******************************************************
+	// Probably should be a size_t return, but uo can only handle a uint32
+	auto CountOfObjects(ObjectType type) const -> std::uint32_t ;
+	
+	auto SizeOfObjects(ObjectType type) const ->size_t;
 };
 
-#endif
-
+#endif /* ObjectFactory_hpp */

--- a/source/ObjectFactory.h
+++ b/source/ObjectFactory.h
@@ -6,6 +6,9 @@
 #include <unordered_map>
 #include <functional>
 
+// *******************************
+// Unfortunately Prerequisites.h includes EVERY header (almost), and we wonder why it is slow
+// Should be addressed
 #include "Prerequisites.h"
 #include "typedefs.h"
 using factory_collection = std::unordered_map<std::uint32_t, CBaseObject*>;

--- a/source/SEFunctions.cpp
+++ b/source/SEFunctions.cpp
@@ -2075,25 +2075,24 @@ JSBool SE_AreaCharacterFunction( JSContext *cx, JSObject *obj, uintN argc, jsval
 
 	UI16 retCounter				= 0;
 	cScript *myScript			= JSMapping->GetScript( JS_GetGlobalObject( cx ) );
-	REGIONLIST nearbyRegions	= MapRegion->PopulateList( srcObject );
-	for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
+	auto nearbyRegions	= MapRegion->PopulateList( srcObject );
+	for(auto &MapArea : nearbyRegions )
 	{
-		CMapRegion *MapArea = (*rIter);
-		if( MapArea == nullptr )	// no valid region
-			continue;
-		GenericList< CChar * > *regChars = MapArea->GetCharList();
-		regChars->Push();
-		for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
-		{
-			if( !ValidateObject( tempChar ) )
-				continue;
-			if( objInRange( srcObject, tempChar, (UI16)distance ) )
+		if( MapArea!= nullptr ){	// no valid region
+			GenericList< CChar * > *regChars = MapArea->GetCharList();
+			regChars->Push();
+			for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
 			{
-				if( myScript->AreaObjFunc( trgFunc, srcObject, tempChar, srcSocket ) )
-					++retCounter;
+				if( !ValidateObject( tempChar ) )
+					continue;
+				if( objInRange( srcObject, tempChar, (UI16)distance ) )
+				{
+					if( myScript->AreaObjFunc( trgFunc, srcObject, tempChar, srcSocket ) )
+						++retCounter;
+				}
 			}
+			regChars->Pop();
 		}
-		regChars->Pop();
 	}
 	*rval = INT_TO_JSVAL( retCounter );
 	return JS_TRUE;
@@ -2144,25 +2143,24 @@ JSBool SE_AreaItemFunction( JSContext *cx, JSObject *obj, uintN argc, jsval *arg
 
 	UI16 retCounter					= 0;
 	cScript *myScript				= JSMapping->GetScript( JS_GetGlobalObject( cx ) );
-	REGIONLIST nearbyRegions		= MapRegion->PopulateList( srcObject );
-	for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
+	auto nearbyRegions		= MapRegion->PopulateList( srcObject );
+	for( auto &MapArea:nearbyRegions )
 	{
-		CMapRegion *MapArea = (*rIter);
-		if( MapArea == nullptr )	// no valid region
-			continue;
-		GenericList< CItem * > *regItems = MapArea->GetItemList();
-		regItems->Push();
-		for( CItem *tempItem = regItems->First(); !regItems->Finished(); tempItem = regItems->Next() )
-		{
-			if( !ValidateObject( tempItem ) )
-				continue;
-			if( objInRange( srcObject, tempItem, (UI16)distance ) )
+		if( MapArea != nullptr ){	// no valid region
+			GenericList< CItem * > *regItems = MapArea->GetItemList();
+			regItems->Push();
+			for( CItem *tempItem = regItems->First(); !regItems->Finished(); tempItem = regItems->Next() )
 			{
-				if( myScript->AreaObjFunc( trgFunc, srcObject, tempItem, srcSocket ) )
-					++retCounter;
+				if( !ValidateObject( tempItem ) )
+					continue;
+				if( objInRange( srcObject, tempItem, (UI16)distance ) )
+				{
+					if( myScript->AreaObjFunc( trgFunc, srcObject, tempItem, srcSocket ) )
+						++retCounter;
+				}
 			}
+			regItems->Pop();
 		}
-		regItems->Pop();
 	}
 	*rval = INT_TO_JSVAL( retCounter );
 	return JS_TRUE;

--- a/source/UOXJSMethods.cpp
+++ b/source/UOXJSMethods.cpp
@@ -372,8 +372,8 @@ JSBool Gump( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, jsval *rval 
 {
 	// Allocate the GumpList here and "SetPrivate" it to the Object
 	SEGump *toAdd = new SEGump;
-	toAdd->one = new STRINGLIST;
-	toAdd->two = new STRINGLIST;
+	toAdd->one = new std::vector<std::string>();
+	toAdd->two = new std::vector<std::string>();
 	toAdd->TextID = 0;
 
 	JS_DefineFunctions( cx, obj, CGump_Methods );

--- a/source/UOXJSMethods.cpp
+++ b/source/UOXJSMethods.cpp
@@ -110,10 +110,9 @@ void MethodSpeech( CBaseObject &speaker, char *message, SpeechType sType, COLOUR
 			else
 				searchDistance = DIST_SAMESCREEN;
 
-			SOCKLIST nearbyChars = FindNearbyPlayers( &speaker, searchDistance );
-			for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-			{
-				(*cIter)->Send( &unicodeMessage );
+			auto nearbyChars = FindNearbyPlayers( &speaker, searchDistance );
+			for( auto &sock:nearbyChars){
+				sock->Send( &unicodeMessage );
 			}
 		}
 		else

--- a/source/UOXJSPropertyFuncs.cpp
+++ b/source/UOXJSPropertyFuncs.cpp
@@ -2352,7 +2352,7 @@ JSBool CSpawnRegionProps_getProperty( JSContext *cx, JSObject *obj, jsval id, js
 			case CSPAWNREGP_ITEMLIST:
 			{
 				// This could potentially be a list of item ids - let's convert it to a comma-separated string!
-				STRINGLIST itemList = gPriv->GetItem();
+				auto itemList = gPriv->GetItem();
 				std::string s;
 				for( const auto &piece : itemList )
 				{
@@ -2369,7 +2369,7 @@ JSBool CSpawnRegionProps_getProperty( JSContext *cx, JSObject *obj, jsval id, js
 			case CSPAWNREGP_NPCLIST:
 			{
 				// This could potentially be a list of NPC ids - let's convert it to a comma-separated string!
-				STRINGLIST npcList = gPriv->GetNPC();
+				auto npcList = gPriv->GetNPC();
 				std::string s;
 				for( const auto &piece : npcList )
 				{

--- a/source/ai.cpp
+++ b/source/ai.cpp
@@ -85,28 +85,27 @@ void HandleGuardAI( CChar& mChar )
 {
 	if( !mChar.IsAtWar() )
 	{
-		REGIONLIST nearbyRegions = MapRegion->PopulateList( &mChar );
-		for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
-		{
-			CMapRegion *MapArea = (*rIter);
-			if( MapArea == nullptr )	// no valid region
-				continue;
-			GenericList< CChar * > *regChars = MapArea->GetCharList();
-			regChars->Push();
-			for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
-			{
-				if( isValidAttackTarget( mChar, tempChar ) )
+		auto nearbyRegions = MapRegion->PopulateList( &mChar );
+		for ( auto &MapArea : nearbyRegions){
+			if (MapArea != nullptr){
+				GenericList< CChar * > *regChars = MapArea->GetCharList();
+				regChars->Push();
+				for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
 				{
-					if( !tempChar->IsDead() && ( tempChar->IsCriminal() || tempChar->IsMurderer() ) )
+					if( isValidAttackTarget( mChar, tempChar ) )
 					{
-						Combat->AttackTarget( &mChar, tempChar );
-						mChar.TextMessage( nullptr, 313, TALK, true );
-						regChars->Pop();
-						return;
+						if( !tempChar->IsDead() && ( tempChar->IsCriminal() || tempChar->IsMurderer() ) )
+						{
+							Combat->AttackTarget( &mChar, tempChar );
+							mChar.TextMessage( nullptr, 313, TALK, true );
+							regChars->Pop();
+							return;
+						}
 					}
 				}
+				regChars->Pop();
 			}
-			regChars->Pop();
+
 		}
 	}
 }
@@ -124,58 +123,57 @@ void HandleFighterAI( CChar& mChar )
 		// Fetch scriptTriggers attached to mChar
 		std::vector<UI16> scriptTriggers = mChar.GetScriptTriggers();
 
-		REGIONLIST nearbyRegions = MapRegion->PopulateList( &mChar );
-		for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
-		{
-			CMapRegion *MapArea = (*rIter);
-			if( MapArea == nullptr )	// no valid region
-				continue;
-			GenericList< CChar * > *regChars = MapArea->GetCharList();
-			regChars->Push();
-			for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
-			{
-				if( isValidAttackTarget( mChar, tempChar ) )
+		auto nearbyRegions = MapRegion->PopulateList( &mChar );
+		for (auto &MapArea : nearbyRegions){
+			if (MapArea != nullptr){
+				GenericList< CChar * > *regChars = MapArea->GetCharList();
+				regChars->Push();
+				for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
 				{
-					// Loop through scriptTriggers attached to mChar and see if any have onCombatTarget event
-					// This event will override target selection entirely
-					bool invalidTarget = false;
-					for( auto scriptTrig : scriptTriggers )
+					if( isValidAttackTarget( mChar, tempChar ) )
 					{
-						cScript *toExecute = JSMapping->GetScript( scriptTrig );
-						if( toExecute != nullptr )
+						// Loop through scriptTriggers attached to mChar and see if any have onCombatTarget event
+						// This event will override target selection entirely
+						bool invalidTarget = false;
+						for( auto scriptTrig : scriptTriggers )
 						{
-							SI08 retVal = toExecute->OnAICombatTarget( &mChar, tempChar );
-							if( retVal == -1 ) // No such event found, or returned -1
-								continue;
-							else if( retVal == 0 )
+							cScript *toExecute = JSMapping->GetScript( scriptTrig );
+							if( toExecute != nullptr )
 							{
-								// Invalid target! But look through other scripts with event first
-								invalidTarget = true;
-								continue;
-							}
-							else if( retVal == 1 )
-							{
-								// Valid target!
-								Combat->AttackTarget( &mChar, tempChar );
-								regChars->Pop(); // restore before returning
-								return;
+								SI08 retVal = toExecute->OnAICombatTarget( &mChar, tempChar );
+								if( retVal == -1 ) // No such event found, or returned -1
+									continue;
+								else if( retVal == 0 )
+								{
+									// Invalid target! But look through other scripts with event first
+									invalidTarget = true;
+									continue;
+								}
+								else if( retVal == 1 )
+								{
+									// Valid target!
+									Combat->AttackTarget( &mChar, tempChar );
+									regChars->Pop(); // restore before returning
+									return;
+								}
 							}
 						}
-					}
-					if( invalidTarget )
-						continue;
-					RaceRelate raceComp = Races->Compare( tempChar, &mChar );
-					if( !tempChar->IsDead() && ( tempChar->IsCriminal() || tempChar->IsMurderer() || raceComp <= RACE_ENEMY ))
-					{
-						if( RandomNum( 1, 100 ) >= 85 ) // 85% chance to attack current target, 15% chance to pick another
+						if( invalidTarget )
 							continue;
-						Combat->AttackTarget( &mChar, tempChar );
-						regChars->Pop();
-						return;
+						RaceRelate raceComp = Races->Compare( tempChar, &mChar );
+						if( !tempChar->IsDead() && ( tempChar->IsCriminal() || tempChar->IsMurderer() || raceComp <= RACE_ENEMY ))
+						{
+							if( RandomNum( 1, 100 ) >= 85 ) // 85% chance to attack current target, 15% chance to pick another
+								continue;
+							Combat->AttackTarget( &mChar, tempChar );
+							regChars->Pop();
+							return;
+						}
 					}
 				}
+				regChars->Pop();
 			}
-			regChars->Pop();
+
 		}
 	}
 }
@@ -188,10 +186,10 @@ void HandleFighterAI( CChar& mChar )
 //o-----------------------------------------------------------------------------------------------o
 void HandleHealerAI( CChar& mChar )
 {
-	SOCKLIST nearbyChars = FindNearbyPlayers( &mChar, DIST_NEARBY );
-	for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-	{
-		CSocket *mSock	= (*cIter);
+	auto nearbyChars = FindNearbyPlayers( &mChar, DIST_NEARBY );
+	for( auto mSock:nearbyChars ){
+	
+		
 		CChar *realChar = mSock->CurrcharObj();
 		CMultiObj *multiObj = realChar->GetMultiObj();
 		if( realChar->IsDead() && ( !ValidateObject( multiObj ) || multiObj->GetOwner() == realChar->GetSerial() ))
@@ -230,10 +228,8 @@ void HandleHealerAI( CChar& mChar )
 //o-----------------------------------------------------------------------------------------------o
 void HandleEvilHealerAI( CChar& mChar )
 {
-	SOCKLIST nearbyChars = FindNearbyPlayers( &mChar, DIST_NEARBY );
-	for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-	{
-		CSocket *mSock	= (*cIter);
+	auto nearbyChars = FindNearbyPlayers( &mChar, DIST_NEARBY );
+	for( auto &mSock:nearbyChars ){
 		CChar *realChar	= mSock->CurrcharObj();
 		CMultiObj *multiObj = realChar->GetMultiObj();
 		if( realChar->IsDead() && ( !ValidateObject( multiObj ) || multiObj->GetOwner() == realChar->GetSerial() ))
@@ -275,18 +271,14 @@ void HandleEvilAI( CChar& mChar )
 		// Fetch scriptTriggers attached to mChar
 		std::vector<UI16> scriptTriggers = mChar.GetScriptTriggers();
 
-		REGIONLIST nearbyRegions = MapRegion->PopulateList( &mChar );
-		for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
-		{
-			CMapRegion *MapArea = (*rIter);
-			if( MapArea == nullptr )	// no valid region
-				continue;
+		auto nearbyRegions = MapRegion->PopulateList( &mChar );
+		for (auto &MapArea : nearbyRegions) {
 			GenericList< CChar * > *regChars = MapArea->GetCharList();
-
+			
 			// Chance to reverse list of chars
 			if( RandomNum( 0, 1 ))
 				regChars->Reverse();
-
+			
 			regChars->Push();
 			for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
 			{
@@ -344,7 +336,9 @@ void HandleEvilAI( CChar& mChar )
 				}
 			}
 			regChars->Pop();
+
 		}
+
 	}
 }
 
@@ -361,85 +355,14 @@ void HandleChaoticAI( CChar& mChar )
 		// Fetch scriptTriggers attached to mChar
 		std::vector<UI16> scriptTriggers = mChar.GetScriptTriggers();
 
-		REGIONLIST nearbyRegions = MapRegion->PopulateList( &mChar );
-		for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
-		{
-			CMapRegion *MapArea = (*rIter);
-			if( MapArea == nullptr )	// no valid region
-				continue;
-			GenericList< CChar * > *regChars = MapArea->GetCharList();
-			regChars->Push();
-			for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
-			{
-				if( isValidAttackTarget( mChar, tempChar ) && !checkForValidOwner( mChar, tempChar ) )
-				{
-					// Loop through scriptTriggers attached to mChar and see if any have onCombatTarget event
-					// This event will override target selection entirely
-					bool invalidTarget = false;
-					for( auto scriptTrig : scriptTriggers )
-					{
-						cScript *toExecute = JSMapping->GetScript( scriptTrig );
-						if( toExecute != nullptr )
-						{
-							SI08 retVal = toExecute->OnAICombatTarget( &mChar, tempChar );
-							if( retVal == -1 ) // No such event found, or returned -1
-								continue;
-							else if( retVal == 0 )
-							{
-								// Invalid target! But look through other scripts with event first
-								invalidTarget = true;
-								continue;
-							}
-							else if( retVal == 1 )
-							{
-								// Valid target!
-								Combat->AttackTarget( &mChar, tempChar );
-								regChars->Pop(); // restore before returning
-								return;
-							}
-						}
-					}
-					if( invalidTarget )
-						continue;
-					if( RandomNum( 1, 100 ) >= 85 ) // 85% chance to attack current target, 15% chance to pick another
-						continue;
-					Combat->AttackTarget( &mChar, tempChar );
-					regChars->Pop();
-					return;
-				}
-			}
-			regChars->Pop();
-		}
-	}
-}
-
-//o-----------------------------------------------------------------------------------------------o
-//|	Function	-	void HandleAnimalAI( CChar& mChar )
-//|	Date		-	21. Feb, 2006
-//o-----------------------------------------------------------------------------------------------o
-//|	Purpose		-	Handles Animal AI Type
-//o-----------------------------------------------------------------------------------------------o
-void HandleAnimalAI( CChar& mChar )
-{
-	if( !mChar.IsAtWar() )
-	{
-		// Fetch scriptTriggers attached to mChar
-		std::vector<UI16> scriptTriggers = mChar.GetScriptTriggers();
-
-		REGIONLIST nearbyRegions = MapRegion->PopulateList( &mChar );
-		for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
-		{
-			const SI08 hunger = mChar.GetHunger();
-			if( hunger <= 3 )
-			{
-				CMapRegion *MapArea = (*rIter);
-				if( MapArea == nullptr )	// no valid region
-					continue;
+		auto nearbyRegions = MapRegion->PopulateList( &mChar );
+		for ( auto &MapArea : nearbyRegions){
+			if (MapArea != nullptr){
 				GenericList< CChar * > *regChars = MapArea->GetCharList();
 				regChars->Push();
 				for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
 				{
-					if( isValidAttackTarget( mChar, tempChar ) )
+					if( isValidAttackTarget( mChar, tempChar ) && !checkForValidOwner( mChar, tempChar ) )
 					{
 						// Loop through scriptTriggers attached to mChar and see if any have onCombatTarget event
 						// This event will override target selection entirely
@@ -469,19 +392,87 @@ void HandleAnimalAI( CChar& mChar )
 						}
 						if( invalidTarget )
 							continue;
-						RaceRelate raceComp = Races->Compare( tempChar, &mChar );
-						if( raceComp <= RACE_ENEMY || ( cwmWorldState->creatures[tempChar->GetID()].IsAnimal() && tempChar->GetNPCAiType() == AI_NONE ) 
-							|| ( hunger <= 1 && ( tempChar->GetNPCAiType() == AI_ANIMAL || cwmWorldState->creatures[tempChar->GetID()].IsHuman() )))
-						{
-							if( RandomNum( 1, 100 ) <= 95 ) // 5% chance (per AI cycle to attack tempChar)
-								continue;
-							Combat->AttackTarget( &mChar, tempChar );
-							regChars->Pop();
-							return;
-						}
+						if( RandomNum( 1, 100 ) >= 85 ) // 85% chance to attack current target, 15% chance to pick another
+							continue;
+						Combat->AttackTarget( &mChar, tempChar );
+						regChars->Pop();
+						return;
 					}
 				}
 				regChars->Pop();
+			}
+		}
+
+	}
+}
+
+//o-----------------------------------------------------------------------------------------------o
+//|	Function	-	void HandleAnimalAI( CChar& mChar )
+//|	Date		-	21. Feb, 2006
+//o-----------------------------------------------------------------------------------------------o
+//|	Purpose		-	Handles Animal AI Type
+//o-----------------------------------------------------------------------------------------------o
+void HandleAnimalAI( CChar& mChar )
+{
+	if( !mChar.IsAtWar() )
+	{
+		// Fetch scriptTriggers attached to mChar
+		std::vector<UI16> scriptTriggers = mChar.GetScriptTriggers();
+
+		auto nearbyRegions = MapRegion->PopulateList( &mChar );
+		for ( auto &MapArea : nearbyRegions){
+			if (MapArea != nullptr){
+				const SI08 hunger = mChar.GetHunger();
+				if( hunger <= 3 )
+				{
+					GenericList< CChar * > *regChars = MapArea->GetCharList();
+					regChars->Push();
+					for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
+					{
+						if( isValidAttackTarget( mChar, tempChar ) )
+						{
+							// Loop through scriptTriggers attached to mChar and see if any have onCombatTarget event
+							// This event will override target selection entirely
+							bool invalidTarget = false;
+							for( auto scriptTrig : scriptTriggers )
+							{
+								cScript *toExecute = JSMapping->GetScript( scriptTrig );
+								if( toExecute != nullptr )
+								{
+									SI08 retVal = toExecute->OnAICombatTarget( &mChar, tempChar );
+									if( retVal == -1 ) // No such event found, or returned -1
+										continue;
+									else if( retVal == 0 )
+									{
+										// Invalid target! But look through other scripts with event first
+										invalidTarget = true;
+										continue;
+									}
+									else if( retVal == 1 )
+									{
+										// Valid target!
+										Combat->AttackTarget( &mChar, tempChar );
+										regChars->Pop(); // restore before returning
+										return;
+									}
+								}
+							}
+							if( invalidTarget )
+								continue;
+							RaceRelate raceComp = Races->Compare( tempChar, &mChar );
+							if( raceComp <= RACE_ENEMY || ( cwmWorldState->creatures[tempChar->GetID()].IsAnimal() && tempChar->GetNPCAiType() == AI_NONE )
+							   || ( hunger <= 1 && ( tempChar->GetNPCAiType() == AI_ANIMAL || cwmWorldState->creatures[tempChar->GetID()].IsHuman() )))
+							{
+								if( RandomNum( 1, 100 ) <= 95 ) // 5% chance (per AI cycle to attack tempChar)
+									continue;
+								Combat->AttackTarget( &mChar, tempChar );
+								regChars->Pop();
+								return;
+							}
+						}
+					}
+					regChars->Pop();
+				}
 			}
 		}
 	}

--- a/source/boats.cpp
+++ b/source/boats.cpp
@@ -574,11 +574,10 @@ void MoveBoat( UI08 dir, CBoatObj *boat )
 		return;
 
 	CPPauseResume prSend( 0 );
-	SOCKLIST nearbyChars = FindNearbyPlayers( boat, DIST_BUILDRANGE );
-	SOCKLIST_CITERATOR cIter;
-	for( cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-	{
-		( *cIter )->Send( &prSend );
+	auto nearbyChars = FindNearbyPlayers( boat, DIST_BUILDRANGE );
+	for(auto &mSock:nearbyChars ){
+	
+		mSock->Send( &prSend );
 	}
 
 	SI16 tx = 0, ty = 0;
@@ -621,10 +620,9 @@ void MoveBoat( UI08 dir, CBoatObj *boat )
 	if( BlockBoat( boat, tx, ty, dir, boat->GetDir(), false ) )
 	{
 		boat->SetMoveType( 0 );
-		for( cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter  )
-		{
-			(*cIter)->Send( &prSend );
-			tiller->TextMessage( (*cIter), 9 );
+		for( auto &sock:nearbyChars  ){
+			sock->Send( &prSend );
+			tiller->TextMessage( sock, 9 );
 		}
 		return;
 	}
@@ -682,9 +680,8 @@ void MoveBoat( UI08 dir, CBoatObj *boat )
 			bChar->Update();
 		}
 	}
-	for( cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter  )
-	{
-		(*cIter)->Send( &prSend );
+	for( auto &sock:nearbyChars  ){
+		sock->Send( &prSend );
 	}
 }
 
@@ -721,11 +718,11 @@ void TurnBoat( CBoatObj *b, bool rightTurn, bool disableChecks )
 	UI08 olddir = b->GetDir();
 
 	CPPauseResume prSend( 0 );
-	SOCKLIST nearbyChars = FindNearbyPlayers( b, DIST_BUILDRANGE );
-	SOCKLIST_CITERATOR cIter;
-	for( cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter  )
-	{
-		(*cIter)->Send( &prSend );
+	auto nearbyChars = FindNearbyPlayers( b, DIST_BUILDRANGE );
+	
+	for( auto &mSock:nearbyChars){
+	
+		mSock->Send( &prSend );
 	}
 
 	CItem *tiller = calcItemObjFromSer( b->GetTiller() );
@@ -762,10 +759,9 @@ void TurnBoat( CBoatObj *b, bool rightTurn, bool disableChecks )
 		if( BlockBoat( b, 0, 0, b->GetDir(), olddir, true ) )
 		{
 			b->SetDir( olddir );
-			for( cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter  )
-			{
-				(*cIter)->Send( &prSend );
-				tiller->TextMessage( (*cIter), 1410, 0, 0x0481 );
+			for( auto &sock:nearbyChars){
+				sock->Send( &prSend );
+				tiller->TextMessage( sock, 1410, 0, 0x0481 );
 			}
 			return;
 		}
@@ -834,8 +830,9 @@ void TurnBoat( CBoatObj *b, bool rightTurn, bool disableChecks )
 		default: Console.error( oldstrutil::format("TurnBoat() more1 error! more1 = %c not found!", b->GetTempVar( CITV_MOREZ, 1 ) ));
 	}
 
-	for( cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter  )
-		(*cIter)->Send( &prSend );
+	for(auto &sock : nearbyChars ){
+		sock->Send( &prSend );
+	}
 }
 
 void TurnBoat( CSocket *mSock, CBoatObj *myBoat, CItem *tiller, UI08 dir, bool rightTurn )

--- a/source/books.cpp
+++ b/source/books.cpp
@@ -185,7 +185,7 @@ void cBooks::OpenBook( CSocket *mSock, CItem *mBook, bool isWriteable )
 				for( UI16 pageNum = 0; pageNum < numPages; ++pageNum )
 				{
 					UI08 blankLineCtr = 0;
-					STRINGLIST tempLines;
+					std::vector<std::string> tempLines;
 					tempLines.resize( 0 );
 					for( UI08 lineNum = 0; lineNum < 8; ++lineNum )
 					{

--- a/source/cItem.cpp
+++ b/source/cItem.cpp
@@ -3184,17 +3184,17 @@ bool CSpawnItem::HandleSpawnContainer( void )
 					for( int i = 0; i < itemListSize; i++ )
 					{
 						// listObj will either contain an itemID and amount, or an itemlist/lootlist tag
-						STRINGLIST listObj = oldstrutil::sections( oldstrutil::trim( oldstrutil::removeTrailing( itemList->MoveTo( i ), "//" )), "," );
+						auto listObj = oldstrutil::sections( oldstrutil::trim( oldstrutil::removeTrailing( itemList->MoveTo( i ), "//" )), "," );
 						if( !listObj.empty() )
 						{
 							UI16 amountToSpawn = 1;
-							STRINGLIST itemListData;
+							
 							if( oldstrutil::upper( listObj[0] ) == "ITEMLIST" || oldstrutil::upper( listObj[0] ) == "LOOTLIST" )
 							{
 								bool useLootList = oldstrutil::upper( listObj[0] ) == "LOOTLIST";
 
 								// Itemlist/Lootlist
-								itemListData = oldstrutil::sections( oldstrutil::trim( oldstrutil::removeTrailing( itemList->GrabData(), "//" )), "," );
+								auto itemListData = oldstrutil::sections( oldstrutil::trim( oldstrutil::removeTrailing( itemList->GrabData(), "//" )), "," );
 								listEntry = itemListData[0];
 
 								if( itemListData.size() > 1 )

--- a/source/cScript.cpp
+++ b/source/cScript.cpp
@@ -2322,8 +2322,8 @@ size_t cScript::NewGumpList( void )
 {
 	size_t retVal	= gumpDisplays.size();
 	SEGump *toAdd	= new SEGump;
-	toAdd->one		= new STRINGLIST;
-	toAdd->two		= new STRINGLIST;
+	toAdd->one		= new std::vector<std::string>();
+	toAdd->two		= new std::vector<std::string>();
 
 	gumpDisplays.push_back( toAdd );
 	return retVal;

--- a/source/cScript.h
+++ b/source/cScript.h
@@ -114,13 +114,13 @@ enum ScriptEvent
 
 struct SEGump
 {
-	STRINGLIST *one, *two;
+	std::vector<std::string> *one, *two;
 	UI32 TextID;
 };
 
 struct SEGumpData
 {
-	STRINGLIST			sEdits;
+	std::vector<std::string>			sEdits;
 	std::vector<SI32>	nButtons;
 	std::vector<SI16>	nIDs;
 };

--- a/source/cServerData.cpp
+++ b/source/cServerData.cpp
@@ -5284,14 +5284,14 @@ void CServerData::PostLoadDefaults( void )
 }
 
 //o-----------------------------------------------------------------------------------------------o
-//|	Function	-	LPSTARTLOCATION ServerLocation( size_t locNum )
+//|	Function	-	auto ServerLocation( size_t locNum ) -> start_location*
 //|					void ServerLocation( std::string toSet )
 //o-----------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets/Sets server start locations
 //o-----------------------------------------------------------------------------------------------o
-LPSTARTLOCATION CServerData::ServerLocation( size_t locNum )
+auto CServerData::ServerLocation( size_t locNum ) ->start_location*
 {
-	LPSTARTLOCATION rvalue = nullptr;
+	start_location *rvalue = nullptr;
 	if( locNum < startlocations.size() )
 		rvalue = &startlocations[locNum];
 	return rvalue;
@@ -5304,32 +5304,32 @@ void CServerData::ServerLocation( std::string toSet )
 	
 	if( csecs.size() ==  7 )	// Wellformed server location
 	{
-		STARTLOCATION toAdd;
+		start_location toAdd;
 		toAdd.x				= static_cast<SI16>(std::stoi(oldstrutil::trim( oldstrutil::removeTrailing( csecs[2], "//" )), nullptr, 0));
 		toAdd.y				= static_cast<SI16>(std::stoi(oldstrutil::trim( oldstrutil::removeTrailing( csecs[3], "//" )), nullptr, 0));
 		toAdd.z				= static_cast<SI16>(std::stoi(oldstrutil::trim( oldstrutil::removeTrailing( csecs[4], "//" )), nullptr, 0));
 		toAdd.worldNum		= static_cast<SI16>(std::stoi(oldstrutil::trim( oldstrutil::removeTrailing( csecs[5], "//" )), nullptr, 0));
 		toAdd.instanceID	= 0;
 		toAdd.clilocDesc	= static_cast<UI32>(std::stoul(oldstrutil::trim( oldstrutil::removeTrailing( csecs[6], "//" )), nullptr, 0));
-		strcopy( toAdd.oldTown,31, oldstrutil::trim( oldstrutil::removeTrailing( csecs[0], "//" )).c_str() );
-		strcopy( toAdd.oldDescription,31, oldstrutil::trim( oldstrutil::removeTrailing( csecs[1], "//" )).c_str() );
-		strcopy( toAdd.newTown,31, toAdd.oldTown);
-		strcopy( toAdd.newDescription,31, toAdd.oldDescription );
+		toAdd.oldTown = oldstrutil::trim( oldstrutil::removeTrailing( csecs[0], "//" )) ;
+		toAdd.oldDescription = oldstrutil::trim( oldstrutil::removeTrailing( csecs[1], "//" ));
+		toAdd.newTown = toAdd.oldTown;
+		toAdd.newDescription  = toAdd.oldDescription ;
 		startlocations.push_back( toAdd );
 	}
 	else if( csecs.size() ==  8 )	// instanceID included
 	{
-		STARTLOCATION toAdd;
+		start_location toAdd;
 		toAdd.x				= static_cast<SI16>(std::stoi(oldstrutil::trim( oldstrutil::removeTrailing( csecs[2], "//" )), nullptr, 0));
 		toAdd.y				= static_cast<SI16>(std::stoi(oldstrutil::trim( oldstrutil::removeTrailing( csecs[3], "//" )), nullptr, 0));
 		toAdd.z				= static_cast<SI16>(std::stoi(oldstrutil::trim( oldstrutil::removeTrailing( csecs[4], "//" )), nullptr, 0));
 		toAdd.worldNum		= static_cast<SI16>(std::stoi(oldstrutil::trim( oldstrutil::removeTrailing( csecs[5], "//" )), nullptr, 0));
 		toAdd.instanceID	= static_cast<SI16>(std::stoi(oldstrutil::trim( oldstrutil::removeTrailing( csecs[6], "//" )), nullptr, 0));
 		toAdd.clilocDesc	= static_cast<UI32>(std::stoul(oldstrutil::trim( oldstrutil::removeTrailing( csecs[7], "//" )), nullptr, 0));
-		strcopy( toAdd.oldTown,31, oldstrutil::trim( oldstrutil::removeTrailing( csecs[0], "//" )).c_str() );
-		strcopy( toAdd.oldDescription,31 ,oldstrutil::trim( oldstrutil::removeTrailing( csecs[1], "//" )).c_str() );
-		strcopy( toAdd.newTown,31, toAdd.oldTown);
-		strcopy( toAdd.newDescription,31, toAdd.oldDescription );
+		toAdd.oldTown = oldstrutil::trim( oldstrutil::removeTrailing( csecs[0], "//" )) ;
+		toAdd.oldDescription = oldstrutil::trim( oldstrutil::removeTrailing( csecs[1], "//" ));
+		toAdd.newTown = toAdd.oldTown;
+		toAdd.newDescription  = toAdd.oldDescription ;
 		startlocations.push_back( toAdd );
 	}
 	else

--- a/source/cServerData.h
+++ b/source/cServerData.h
@@ -171,6 +171,29 @@ private:
 	UI16 port;
 };
 
+struct start_location
+{
+	start_location()
+	{
+		x= 0;
+		y=0;
+		z=0;
+		worldNum = 0;
+		instanceID = 0 ;
+		clilocDesc = 0 ;
+	}
+	std::string oldTown ; // 31
+	std::string	oldDescription; //31
+	std::string	newTown; //32
+	std::string	newDescription; //32
+	SI16	x;
+	SI16	y;
+	SI16	z;
+	SI16	worldNum;
+	UI16	instanceID;
+	UI32	clilocDesc;
+	
+};
 class CServerData
 {
 private:
@@ -332,7 +355,7 @@ private:
 	UI08		alchemyDamageBonusModifier;		//  Modifier used to calculate bonus damage for explosion potions based on alchemy skill
 
 	// Start & Location Settings
-	std::vector< STARTLOCATION >	startlocations;
+	std::vector< start_location >	startlocations;
 	SI16		startgold;						//	Amount of gold created when a PC is made
 	UI16		startprivs;						//	Starting privileges of characters
 
@@ -955,7 +978,7 @@ public:
 	void		dumpPaths( void );
 
 	void			ServerLocation( std::string toSet );
-	LPSTARTLOCATION ServerLocation( size_t locNum );
+	auto		ServerLocation( size_t locNum ) ->start_location*;
 
 	size_t			NumServerLocations( void ) const;
 

--- a/source/cServerDefinitions.cpp
+++ b/source/cServerDefinitions.cpp
@@ -241,8 +241,8 @@ void CServerDefinitions::LoadDFNCategory( DEFINITIONCATEGORIES toLoad )
 
 	cDirectoryListing fileList( toLoad, defExt );
 	fileList.Flatten( true );
-	STRINGLIST *shortListing	= fileList.FlattenedShortList();
-	STRINGLIST *longListing		= fileList.FlattenedList();
+	auto shortListing	= fileList.FlattenedShortList();
+	auto longListing	= fileList.FlattenedList();
 
 	std::vector< PrioScan >	mSort;
 	for( size_t i = 0; i < shortListing->size(); ++i )
@@ -341,7 +341,7 @@ void CServerDefinitions::CleanPriorityMap( void )
 void CServerDefinitions::BuildPriorityMap( DEFINITIONCATEGORIES category, UI08& wasPrioritized )
 {
 	cDirectoryListing priorityFile( category, "priority.nfo", false );
-	STRINGLIST *longList = priorityFile.List();
+	auto longList = priorityFile.List();
 	if( !longList->empty() )
 	{
 		std::string filename = (*longList)[0];
@@ -496,23 +496,19 @@ void cDirectoryListing::Retrieve( DEFINITIONCATEGORIES dir )
 		PopDir();
 }
 
-STRINGLIST *cDirectoryListing::List( void )
-{
+auto cDirectoryListing::List( void )->std::vector<std::string>*{
 	return &filenameList;
 }
 
-STRINGLIST *cDirectoryListing::ShortList( void )
-{
+auto cDirectoryListing::ShortList( void )->std::vector<std::string>*{
 	return &shortList;
 }
 
-STRINGLIST *cDirectoryListing::FlattenedList( void )
-{
+auto cDirectoryListing::FlattenedList( void )->std::vector<std::string>*{
 	return &flattenedFull;
 }
 
-STRINGLIST *cDirectoryListing::FlattenedShortList( void )
-{
+auto cDirectoryListing::FlattenedShortList( void )->std::vector<std::string>*{
 	return &flattenedShort;
 }
 
@@ -574,8 +570,8 @@ void cDirectoryListing::Flatten( bool isParent )
 	for( dIter = subdirectories.begin(); dIter != subdirectories.end(); ++dIter )
 	{
 		(*dIter).Flatten( false );
-		STRINGLIST *shortFlat	= (*dIter).FlattenedShortList();
-		STRINGLIST *longFlat	= (*dIter).FlattenedList();
+		auto shortFlat	= (*dIter).FlattenedShortList();
+		auto longFlat	= (*dIter).FlattenedList();
 		for( size_t k = 0; k < longFlat->size(); ++k )
 		{
 			flattenedFull.push_back( (*longFlat)[k] );

--- a/source/cServerDefinitions.cpp
+++ b/source/cServerDefinitions.cpp
@@ -556,10 +556,10 @@ void cDirectoryListing::Flatten( bool isParent )
 {
 	ClearFlatten();
 	std::string temp;
-	STRINGLIST_ITERATOR sIter;
-	for( sIter = filenameList.begin(); sIter != filenameList.end(); ++sIter )
+	
+	for( auto &sIter : filenameList)
 	{
-		flattenedFull.push_back( (*sIter) );
+		flattenedFull.push_back( sIter );
 		if( isParent )
 			temp = "";
 		else
@@ -567,7 +567,7 @@ void cDirectoryListing::Flatten( bool isParent )
 			temp = shortCurrentDir;
 			temp += "/";
 		}
-		temp += (*sIter);
+		temp += sIter;
 		flattenedShort.push_back( temp );
 	}
 	DIRLIST_ITERATOR dIter;

--- a/source/cServerDefinitions.h
+++ b/source/cServerDefinitions.h
@@ -18,8 +18,8 @@ private:
 	bool			PushDir( std::string toMove );
 	void			PopDir( void );
 
-	STRINGLIST		filenameList, shortList;
-	STRINGLIST		flattenedShort, flattenedFull;
+	std::vector<std::string>		filenameList, shortList;
+	std::vector<std::string>		flattenedShort, flattenedFull;
 	dirList			dirs;
 	std::string		extension;
 	std::string		currentDir;
@@ -42,10 +42,10 @@ public:
 	void			Flatten( bool isParent );
 	void			ClearFlatten( void );
 
-	STRINGLIST *	List( void );
-	STRINGLIST *	ShortList( void );
-	STRINGLIST *	FlattenedList( void );
-	STRINGLIST *	FlattenedShortList( void );
+	auto	List( void ) ->std::vector<std::string>*;
+	auto	ShortList( void ) ->std::vector<std::string>*;
+	auto	FlattenedList( void ) ->std::vector<std::string>*;
+	auto	FlattenedShortList( void ) ->std::vector<std::string>*;
 };
 
 class CServerDefinitions

--- a/source/cSpawnRegion.cpp
+++ b/source/cSpawnRegion.cpp
@@ -365,17 +365,15 @@ void CSpawnRegion::SetCall( UI16 newVal )
 }
 
 //o-----------------------------------------------------------------------------------------------o
-//|	Function	-	STRINGLIST GetNPC( void ) const
-//|					void SetNPC( STRINGLIST newVal )
+//|	Function	-	auto GetNPC( void )  ->std::vector<std::string>const
+//|					void SetNPC( std::string &newVal )
 //o-----------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets/Sets stringlist of individual NPCs to spawn in a spawnregion
 //o-----------------------------------------------------------------------------------------------o
-STRINGLIST CSpawnRegion::GetNPC( void ) const
-{
+auto CSpawnRegion::GetNPC( void )const ->std::vector<std::string>{
 	return sNpcs;
 }
-void CSpawnRegion::SetNPC( const std::string &newVal )
-{
+auto CSpawnRegion::SetNPC( const std::string &newVal ) ->void {
 	// Clear old entries to make room for new ones
 	sNpcs.clear();
 	sNpcs.push_back( newVal );
@@ -408,13 +406,12 @@ void CSpawnRegion::SetNPCList( std::string newVal )
 }
 
 //o-----------------------------------------------------------------------------------------------o
-//|	Function	-	STRINGLIST GetItem( void ) const
-//|					void SetItem( STRINGLIST newVal )
+//|	Function	-	std::vector<std::string> GetItem( void ) const
+//|					void SetItem( const std::string &newVal )
 //o-----------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets/Sets stringlist of individual Items to spawn in a spawnregion
 //o-----------------------------------------------------------------------------------------------o
-STRINGLIST CSpawnRegion::GetItem( void ) const
-{
+auto CSpawnRegion::GetItem( void ) const ->std::vector<std::string>{
 	return sItems;
 }
 void CSpawnRegion::SetItem( const std::string &newVal )

--- a/source/cSpawnRegion.h
+++ b/source/cSpawnRegion.h
@@ -6,8 +6,8 @@ class CSpawnRegion	//Regionspawns
 private:
 	std::string name;			// Any Name to show up when this region is spawned [512]
 
-	STRINGLIST	sNpcs;				// Individual Npcs
-	STRINGLIST 	sItems;				// Individual Items
+	std::vector<std::string>	sNpcs;				// Individual Npcs
+	std::vector<std::string> 	sItems;				// Individual Items
 
 	UI16		regionnum;			// Region Number
 
@@ -71,8 +71,8 @@ public:
 	UI16		GetCall( void ) const;
 	bool		GetOnlyOutside( void ) const;
 	bool		IsSpawner( void ) const;
-	STRINGLIST	GetNPC( void ) const;
-	STRINGLIST	GetItem( void ) const;
+	auto	GetNPC( void ) const ->std::vector<std::string>;
+	auto	GetItem( void ) const ->std::vector<std::string>;
 
 	void		SetName( const std::string& newName );
 	void		SetRegionNum( UI16 newVal );

--- a/source/combat.cpp
+++ b/source/combat.cpp
@@ -370,21 +370,20 @@ void CHandleCombat::PlayerAttack( CSocket *s )
 			petGuardAttack( ourChar, i, i );
 
 		// Send attacker message to all nearby players
-		SOCKLIST nearbyChars = FindNearbyPlayers( ourChar );
-		for( SOCKLIST_ITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-		{
-			if( (*cIter) != nullptr )
+		auto nearbyChars = FindNearbyPlayers( ourChar );
+		for(auto &nearby:nearbyChars ){
+			if( nearby != nullptr )
 			{
 				// Valid socket found
-				CChar *witness = (*cIter)->CurrcharObj();
+				CChar *witness = nearby->CurrcharObj();
 				if( ValidateObject( witness ))
 				{
 					// Fetch names of attacker and target
-					std::string attackerName = getNpcDictName( ourChar, (*cIter) );
-					std::string targetName = getNpcDictName( i, (*cIter) );
+					std::string attackerName = getNpcDictName( ourChar, nearby );
+					std::string targetName = getNpcDictName( i,nearby );
 
 					// Send a TextMessage visible only to the witness
-					ourChar->TextMessage( (*cIter), 334, EMOTE, 0, attackerName.c_str(), targetName.c_str() ); // Attacker emotes "You see attacker attacking target" to all nearby
+					ourChar->TextMessage( nearby, 334, EMOTE, 0, attackerName.c_str(), targetName.c_str() ); // Attacker emotes "You see attacker attacking target" to all nearby
 				}
 			}
 		}
@@ -462,21 +461,21 @@ void CHandleCombat::AttackTarget( CChar *cAttack, CChar *cTarget )
 	if( cAttack->DidAttackFirst() )
 	{
 		// Send attacker message to all nearby players
-		SOCKLIST nearbyChars = FindNearbyPlayers( cAttack );
-		for( SOCKLIST_ITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
+		auto nearbyChars = FindNearbyPlayers( cAttack );
+		for( auto &nearby: nearbyChars )
 		{
-			if( (*cIter) != nullptr )
+			if( nearby != nullptr )
 			{
 				// Valid socket found
-				CChar *witness = (*cIter)->CurrcharObj();
+				CChar *witness = nearby->CurrcharObj();
 				if( ValidateObject( witness ))
 				{
 					// Fetch names of attacker and target
-					std::string attackerName = getNpcDictName( cAttack, (*cIter) );
-					std::string targetName = getNpcDictName( cTarget, (*cIter) );
+					std::string attackerName = getNpcDictName( cAttack, nearby );
+					std::string targetName = getNpcDictName( cTarget, nearby );
 
 					// Send a TextMessage visible only to the witness
-					cAttack->TextMessage( (*cIter), 334, EMOTE, 0, attackerName.c_str(), targetName.c_str() ); // Attacker emotes "You see attacker attacking target" to all nearby
+					cAttack->TextMessage( nearby, 334, EMOTE, 0, attackerName.c_str(), targetName.c_str() ); // Attacker emotes "You see attacker attacking target" to all nearby
 				}
 			}
 		}
@@ -2038,11 +2037,11 @@ bool CHandleCombat::HandleCombat( CSocket *mSock, CChar& mChar, CChar *ourTarg )
 	if( checkDist )
 	{
 		CPFightOccurring tSend( mChar, (*ourTarg) );
-		SOCKLIST nearbyChars = FindNearbyPlayers( &mChar );
-		for( SOCKLIST_ITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
+		auto nearbyChars = FindNearbyPlayers( &mChar );
+		for( auto &nearby:nearbyChars )
 		{
-			if( (*cIter) != nullptr )
-				(*cIter)->Send( &tSend );
+			if( nearby != nullptr )
+				nearby->Send( &tSend );
 		}
 
 		if( mChar.IsNpc() )

--- a/source/commands.cpp
+++ b/source/commands.cpp
@@ -7,6 +7,7 @@
 #include "CPacketSend.h"
 #include "StringUtility.hpp"
 
+#include <algorithm>
 
 cCommands *Commands			= nullptr;
 
@@ -309,12 +310,10 @@ void cCommands::Load( void )
 	if( !badCommands.empty() )
 	{
 		Console << myendl;
-		STRINGLIST_CITERATOR tablePos = badCommands.begin();
-		while( tablePos != badCommands.end() )
-		{
-			Console << "Invalid command '" << (*tablePos).c_str() << "' found in commands.dfn!" << myendl;
-			++tablePos;
-		}
+		std::for_each(badCommands.begin(), badCommands.end(),[] (const std::string &text){
+			Console << "Invalid command '" << text.c_str() << "' found in commands.dfn!" << myendl;
+
+		});
 	}
 
 	Console << "   o Loading command levels";

--- a/source/commands.cpp
+++ b/source/commands.cpp
@@ -285,7 +285,7 @@ void cCommands::Load( void )
 	std::string data;
 	std::string UTag;
 
-	STRINGLIST	badCommands;
+	auto badCommands = std::vector<std::string>();
 	for( tag = commands->First(); !commands->AtEnd(); tag = commands->Next() )
 	{
 		data						= commands->GrabData();

--- a/source/effect.cpp
+++ b/source/effect.cpp
@@ -25,11 +25,10 @@ void cEffects::deathAction( CChar *s, CItem *x, UI08 fallDirection )
 {
 	CPDeathAction toSend( (*s), (*x) );
 	toSend.FallDirection( fallDirection );
-	SOCKLIST nearbyChars = FindNearbyPlayers( s );
-	for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-	{
-		if( (*cIter)->CurrcharObj() != s )	// Death action screws up corpse display for the person who died.
-			(*cIter)->Send( &toSend );
+	auto nearbyChars = FindNearbyPlayers( s );
+	for(auto &mSock:nearbyChars){
+		if( mSock->CurrcharObj() != s )	// Death action screws up corpse display for the person who died.
+			mSock->Send( &toSend );
 	}
 }
 
@@ -141,10 +140,9 @@ void cEffects::PlayMovingAnimation( CBaseObject *source, SI16 x, SI16 y, SI08 z,
 	toSend.Hue( hue );
 	toSend.RenderMode( renderMode );
 
-	SOCKLIST nearbyChars = FindNearbyPlayers( source, DIST_SAMESCREEN );
-	for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-	{
-		(*cIter)->Send( &toSend );
+	auto nearbyChars = FindNearbyPlayers( source, DIST_SAMESCREEN );
+	for( auto &mSock:nearbyChars){
+		mSock->Send( &toSend );
 	}
 }
 
@@ -168,10 +166,9 @@ void cEffects::PlayMovingAnimation( SI16 srcX, SI16 srcY, SI08 srcZ, SI16 x, SI1
 	toSend.Hue( hue );
 	toSend.RenderMode( renderMode );
 
-	SOCKLIST nearbyChars = FindNearbyPlayers( srcX, srcY, srcZ, DIST_SAMESCREEN );
-	for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-	{
-		(*cIter)->Send( &toSend );
+	auto nearbyChars = FindNearbyPlayers( srcX, srcY, srcZ, DIST_SAMESCREEN );
+	for(auto &mSock:nearbyChars ){
+		mSock->Send( &toSend );
 	}
 }
 
@@ -187,10 +184,10 @@ void cEffects::PlayCharacterAnimation( CChar *mChar, UI16 actionID, UI08 frameDe
 	toSend.FrameDelay( frameDelay );
 	toSend.FrameCount( frameCount );
 	toSend.DoBackwards( playBackwards );
-	SOCKLIST nearbyChars = FindNearbyPlayers( mChar );
-	for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-	{
-		(*cIter)->Send( &toSend );
+	auto nearbyChars = FindNearbyPlayers( mChar );
+	for( auto &mSock:nearbyChars ){
+	
+		mSock->Send( &toSend );
 	}
 }
 
@@ -206,10 +203,9 @@ void cEffects::PlayNewCharacterAnimation( CChar *mChar, UI16 actionID, UI16 subA
 	toSend.Action( actionID );
 	toSend.SubAction( subActionID );
 	toSend.SubSubAction( subSubActionID );
-	SOCKLIST nearbyChars = FindNearbyPlayers( mChar );
-	for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-	{
-		(*cIter)->Send( &toSend );
+	auto nearbyChars = FindNearbyPlayers( mChar );
+	for(auto &mSock:nearbyChars){
+		mSock->Send( &toSend );
 	}
 }
 
@@ -279,10 +275,10 @@ void cEffects::PlayStaticAnimation( CBaseObject *target, UI16 effect, UI08 speed
 	toSend.AdjustDir( false );
 	toSend.ExplodeOnImpact( explode );
 
-	SOCKLIST nearbyChars = FindNearbyPlayers( target, DIST_SAMESCREEN );
-	for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-	{
-		(*cIter)->Send( &toSend );
+	auto nearbyChars = FindNearbyPlayers( target, DIST_SAMESCREEN );
+	for( auto &mSock:nearbyChars ){
+
+		mSock->Send( &toSend );
 	}
 }
 
@@ -324,10 +320,9 @@ void cEffects::bolteffect( CChar *player )
 	toSend.SourceLocation( (*player) );
 	toSend.ExplodeOnImpact( false );
 	toSend.AdjustDir( false );
-	SOCKLIST nearbyChars = FindNearbyPlayers( player );
-	for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-	{
-		(*cIter)->Send( &toSend );
+	auto nearbyChars = FindNearbyPlayers( player );
+	for( auto &mSock:nearbyChars ){
+		mSock->Send( &toSend );
 	}
 }
 
@@ -369,64 +364,65 @@ void explodeItem( CSocket *mSock, CItem *nItem, UI32 damage = 0, UI08 damageType
 	if( explodeNearby )
 	{
 		// Explode for characters nearby
-		REGIONLIST nearbyRegions = MapRegion->PopulateList( nItem );
-		for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
+		auto nearbyRegions = MapRegion->PopulateList( nItem );
+		for( auto &Cell:nearbyRegions)
 		{
-			CMapRegion *Cell = (*rIter);
-			bool chain = false;
-
-			GenericList< CChar * > *regChars = Cell->GetCharList();
-			regChars->Push();
-			for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
-			{
-				if( !ValidateObject( tempChar ) || tempChar->GetInstanceID() != nItem->GetInstanceID() )
-					continue;
-				if( tempChar->GetRegion()->IsSafeZone() )
+			if (Cell != nullptr){
+				bool chain = false;
+				
+				GenericList< CChar * > *regChars = Cell->GetCharList();
+				regChars->Push();
+				for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
 				{
-					// Character is in a safe zone, ignore damage
-					continue;
-				}
-				dx = abs( tempChar->GetX() - nItem->GetX() );
-				dy = abs( tempChar->GetY() - nItem->GetY() );
-				dz = abs( tempChar->GetZ() - nItem->GetZ() );
-				if( dx <= len && dy <= len && dz <= len )
-				{
-					if( !tempChar->IsGM() && !tempChar->IsInvulnerable() && ( tempChar->IsNpc() || isOnline( (*tempChar) ) ) )
+					if( !ValidateObject( tempChar ) || tempChar->GetInstanceID() != nItem->GetInstanceID() )
+						continue;
+					if( tempChar->GetRegion()->IsSafeZone() )
 					{
-						//UI08 hitLoc = Combat->CalculateHitLoc();
-						damage = Combat->ApplyDefenseModifiers( HEAT, c, tempChar, ALCHEMY, 0, ( static_cast<SI32>(damage) + ( 2 - std::min( dx, dy ))), true );
-						[[maybe_unused]] bool retVal = tempChar->Damage( static_cast<SI16>(damage), HEAT, c, true );
+						// Character is in a safe zone, ignore damage
+						continue;
 					}
-				}
-			}
-			regChars->Pop();
-			GenericList< CItem * > *regItems = Cell->GetItemList();
-			regItems->Push();
-			for( CItem *tempItem = regItems->First(); !regItems->Finished(); tempItem = regItems->Next() )
-			{
-				if( tempItem->GetInstanceID() != nItem->GetInstanceID() )
-				{
-					// Item is in a different instanceID - ignore
-					continue;
-				}
-				if( tempItem->GetID() == 0x0F0D && tempItem->GetType() == IT_POTION )
-				{
-					dx = abs( nItem->GetX() - tempItem->GetX() );
-					dy = abs( nItem->GetY() - tempItem->GetY() );
-					dz = abs( nItem->GetZ() - tempItem->GetZ() );
-
-					if( dx <= 2 && dy <= 2 && dz <= 2 && !chain ) // only trigger if in a 2*2*2 cube
+					dx = abs( tempChar->GetX() - nItem->GetX() );
+					dy = abs( tempChar->GetY() - nItem->GetY() );
+					dz = abs( tempChar->GetZ() - nItem->GetZ() );
+					if( dx <= len && dy <= len && dz <= len )
 					{
-						if( !( dx == 0 && dy == 0 && dz == 0 ) )
+						if( !tempChar->IsGM() && !tempChar->IsInvulnerable() && ( tempChar->IsNpc() || isOnline( (*tempChar) ) ) )
 						{
-							if( RandomNum( 0, 1 ) == 1 )
-								chain = true;
-							Effects->tempeffect( c, tempItem, 17, 0, 1, 0 );
+							//UI08 hitLoc = Combat->CalculateHitLoc();
+							damage = Combat->ApplyDefenseModifiers( HEAT, c, tempChar, ALCHEMY, 0, ( static_cast<SI32>(damage) + ( 2 - std::min( dx, dy ))), true );
+							[[maybe_unused]] bool retVal = tempChar->Damage( static_cast<SI16>(damage), HEAT, c, true );
 						}
 					}
 				}
+				regChars->Pop();
+				GenericList< CItem * > *regItems = Cell->GetItemList();
+				regItems->Push();
+				for( CItem *tempItem = regItems->First(); !regItems->Finished(); tempItem = regItems->Next() )
+				{
+					if( tempItem->GetInstanceID() != nItem->GetInstanceID() )
+					{
+						// Item is in a different instanceID - ignore
+						continue;
+					}
+					if( tempItem->GetID() == 0x0F0D && tempItem->GetType() == IT_POTION )
+					{
+						dx = abs( nItem->GetX() - tempItem->GetX() );
+						dy = abs( nItem->GetY() - tempItem->GetY() );
+						dz = abs( nItem->GetZ() - tempItem->GetZ() );
+						
+						if( dx <= 2 && dy <= 2 && dz <= 2 && !chain ) // only trigger if in a 2*2*2 cube
+						{
+							if( !( dx == 0 && dy == 0 && dz == 0 ) )
+							{
+								if( RandomNum( 0, 1 ) == 1 )
+									chain = true;
+								Effects->tempeffect( c, tempItem, 17, 0, 1, 0 );
+							}
+						}
+					}
+				}
+				regItems->Pop();
 			}
-			regItems->Pop();
 		}
 	}
 	else

--- a/source/findfuncs.cpp
+++ b/source/findfuncs.cpp
@@ -5,13 +5,12 @@
 #include "classes.h"
 
 //o-----------------------------------------------------------------------------------------------o
-//|	Function	-	SOCKLIST FindPlayersInOldVisrange( CBaseObject *myObj )
+//|	Function	-	std::vector< CSocket * > FindPlayersInOldVisrange( CBaseObject *myObj )
 //o-----------------------------------------------------------------------------------------------o
 //|	Purpose		-	Find players who previously were in visual range of an object
 //o-----------------------------------------------------------------------------------------------o
-SOCKLIST FindPlayersInOldVisrange( CBaseObject *myObj )
-{
-	SOCKLIST nearbyChars;
+auto FindPlayersInOldVisrange( CBaseObject *myObj ) ->std::vector< CSocket * >{
+	auto  nearbyChars = std::vector< CSocket * >();
 	//std::scoped_lock lock(Network->internallock);
 	Network->pushConn();
 	for( CSocket *mSock = Network->FirstSocket(); !Network->FinishedSockets(); mSock = Network->NextSocket() )
@@ -41,13 +40,13 @@ SOCKLIST FindPlayersInOldVisrange( CBaseObject *myObj )
 }
 
 //o-----------------------------------------------------------------------------------------------o
-//|	Function	-	SOCKLIST FindPlayersInVisrange( CBaseObject *myObj )
+//|	Function	-	std::vector< CSocket * > FindPlayersInVisrange( CBaseObject *myObj )
 //o-----------------------------------------------------------------------------------------------o
 //|	Purpose		-	Find players in visual range of an object
 //o-----------------------------------------------------------------------------------------------o
-SOCKLIST FindPlayersInVisrange( CBaseObject *myObj )
+auto FindPlayersInVisrange( CBaseObject *myObj ) ->std::vector< CSocket * >
 {
-	SOCKLIST nearbyChars;
+	auto nearbyChars = std::vector< CSocket * >();
 	//std::scoped_lock lock(Network->internallock);
 	Network->pushConn();
 	for( CSocket *mSock = Network->FirstSocket(); !Network->FinishedSockets(); mSock = Network->NextSocket() )
@@ -67,13 +66,12 @@ SOCKLIST FindPlayersInVisrange( CBaseObject *myObj )
 }
 
 //o-----------------------------------------------------------------------------------------------o
-//|	Function	-	SOCKLIST FindNearbyPlayers( CBaseObject *myObj, UI16 distance )
+//|	Function	-	std::vector< CSocket * > FindNearbyPlayers( CBaseObject *myObj, UI16 distance )
 //o-----------------------------------------------------------------------------------------------o
 //|	Purpose		-	Find players who within a certain distance of an object
 //o-----------------------------------------------------------------------------------------------o
-SOCKLIST FindNearbyPlayers( CBaseObject *myObj, UI16 distance )
-{
-	SOCKLIST nearbyChars;
+auto FindNearbyPlayers( CBaseObject *myObj, UI16 distance )->std::vector< CSocket * >{
+	auto nearbyChars=std::vector< CSocket * >();
 	//std::scoped_lock lock(Network->internallock);
 	Network->pushConn();
 	for( CSocket *mSock = Network->FirstSocket(); !Network->FinishedSockets(); mSock = Network->NextSocket() )
@@ -88,8 +86,8 @@ SOCKLIST FindNearbyPlayers( CBaseObject *myObj, UI16 distance )
 	Network->popConn();
 	return nearbyChars;
 }
-SOCKLIST FindNearbyPlayers( CChar *mChar )
-{
+//===============================================================
+auto FindNearbyPlayers( CChar *mChar )->std::vector< CSocket * >{
 	UI16 visRange = MAX_VISRANGE;
 	if( mChar->GetSocket() != nullptr )
 		visRange = static_cast<UI16>(mChar->GetSocket()->Range() + Races->VisRange( mChar->GetRace() ));
@@ -97,16 +95,16 @@ SOCKLIST FindNearbyPlayers( CChar *mChar )
 		visRange += static_cast<UI16>(Races->VisRange( mChar->GetRace() ));
 	return FindNearbyPlayers( mChar, visRange );
 }
+//===============================================================
+auto FindNearbyPlayers( CBaseObject *mObj )->std::vector< CSocket * >{
 
-SOCKLIST FindNearbyPlayers( CBaseObject *mObj )
-{
 	UI16 visRange = static_cast<UI16>(MAX_VISRANGE + Races->VisRange( mObj->GetRace() ));
 	return FindNearbyPlayers( mObj, visRange );
 }
+//========================================================================================
+auto FindNearbyPlayers( SI16 x, SI16 y, SI08 z, UI16 distance )->std::vector< CSocket * >{
 
-SOCKLIST FindNearbyPlayers( SI16 x, SI16 y, SI08 z, UI16 distance )
-{
-	SOCKLIST nearbyChars;
+	auto nearbyChars = std::vector< CSocket * >();
 	//std::scoped_lock lock(Network->internallock);
 	Network->pushConn();
 	for( CSocket *mSock = Network->FirstSocket(); !Network->FinishedSockets(); mSock = Network->NextSocket() )

--- a/source/funcdecl.h
+++ b/source/funcdecl.h
@@ -44,12 +44,12 @@ UI16	getDist( point3 a, point3 b );
 UI16	getOldDist( CBaseObject *a, CBaseObject *b );
 UI16	getDist3D( CBaseObject *a, CBaseObject *b );
 UI16	getDist3D( point3 a, point3 b );
-SOCKLIST	FindPlayersInVisrange( CBaseObject *myObj );
-SOCKLIST	FindPlayersInOldVisrange( CBaseObject *myObj );
-SOCKLIST	FindNearbyPlayers( SI16 x, SI16 y, SI08 z, UI16 distance );
-SOCKLIST	FindNearbyPlayers( CBaseObject *myObj, UI16 distance );
-SOCKLIST	FindNearbyPlayers( CBaseObject *myObj );
-SOCKLIST	FindNearbyPlayers( CChar *mChar );
+auto	FindPlayersInVisrange( CBaseObject *myObj )->std::vector< CSocket * >;
+auto	FindPlayersInOldVisrange( CBaseObject *myObj )->std::vector< CSocket * >;
+auto	FindNearbyPlayers( SI16 x, SI16 y, SI08 z, UI16 distance )->std::vector< CSocket * >;
+auto	FindNearbyPlayers( CBaseObject *myObj, UI16 distance )->std::vector< CSocket * >;
+auto	FindNearbyPlayers( CBaseObject *myObj )->std::vector< CSocket * >;
+auto	FindNearbyPlayers( CChar *mChar )->std::vector< CSocket * >;
 //o-----------------------------------------------------------------------------------------------o
 // Multi functions
 //o-----------------------------------------------------------------------------------------------o
@@ -76,7 +76,7 @@ inline UI32 calcserial( UI08 a1, UI08 a2, UI08 a3, UI08 a4 )
 //o-----------------------------------------------------------------------------------------------o
 // Socket stuff
 //o-----------------------------------------------------------------------------------------------o
-void	SendVecsAsGump( CSocket *sock, STRINGLIST& one, STRINGLIST& two, UI32 type, SERIAL serial );
+void	SendVecsAsGump( CSocket *sock, std::vector<std::string>& one, std::vector<std::string>& two, UI32 type, SERIAL serial );
 void	SendMapChange( UI08 worldNumber, CSocket *sock, bool initialLogin = false );
 bool	isOnline( CChar& mChar );
 

--- a/source/gump.h
+++ b/source/gump.h
@@ -6,8 +6,8 @@ void MultiGumpCallback( CSocket *mySocket, SERIAL GumpSerial, UI32 Button );
 class CGump
 {
 private:
-	STRINGLIST TagList;
-	STRINGLIST TextList;
+	std::vector<std::string> TagList;
+	std::vector<std::string> TextList;
 	bool NoMove;
 	bool NoClose;
 	UI32 Serial;
@@ -56,7 +56,7 @@ private:
 	std::vector< GumpInfo * > gumpData;
 	UI16 width, height;	// gump width / height
 	CSocket *toSendTo;
-	STRINGLIST one, two;
+	std::vector<std::string> one, two;
 	std::string title;
 public:
 	void AddData( GumpInfo *toAdd );

--- a/source/gumps.cpp
+++ b/source/gumps.cpp
@@ -213,33 +213,32 @@ void HandleTownstoneButton( CSocket *s, SERIAL button, SERIAL ser, SERIAL type )
 						// redo stealing code here
 						s->sysmessage( 549, targetRegion->GetName().c_str() );
 						targetRegion->DoDamage( targetRegion->GetHealth() / 2 );	// we reduce the region's health by half
-						REGIONLIST nearbyRegions = MapRegion->PopulateList( mChar );
-						for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
+						auto nearbyRegions = MapRegion->PopulateList( mChar );
+						for( auto &toCheck : nearbyRegions )
 						{
-							CMapRegion *toCheck = (*rIter);
-							if( toCheck == nullptr )	// no valid region
-								continue;
-							GenericList< CItem * > *regItems = toCheck->GetItemList();
-							regItems->Push();
-							for( CItem *itemCheck = regItems->First(); !regItems->Finished(); itemCheck = regItems->Next() )
-							{
-								if( !ValidateObject( itemCheck ) )
-									continue;
-								if( itemCheck->GetType() == IT_TOWNSTONE && itemCheck->GetID() != 0x14F0 )
-								{	// found our townstone
-									CItem *charPack = mChar->GetPackItem();
-									if( ValidateObject( charPack ) )
-									{
-										itemCheck->SetCont( charPack );
-										itemCheck->SetTempVar( CITV_MOREX, targetRegion->GetRegionNum() );
-										s->sysmessage( 550 );
-										targetRegion->TellMembers( 551, mChar->GetName().c_str() ); // Quickly, %s has stolen your treasured townstone!
-										regItems->Pop();
-										return;	// dump out
+							if (toCheck != nullptr){
+								GenericList< CItem * > *regItems = toCheck->GetItemList();
+								regItems->Push();
+								for( CItem *itemCheck = regItems->First(); !regItems->Finished(); itemCheck = regItems->Next() )
+								{
+									if( !ValidateObject( itemCheck ) )
+										continue;
+									if( itemCheck->GetType() == IT_TOWNSTONE && itemCheck->GetID() != 0x14F0 )
+									{	// found our townstone
+										CItem *charPack = mChar->GetPackItem();
+										if( ValidateObject( charPack ) )
+										{
+											itemCheck->SetCont( charPack );
+											itemCheck->SetTempVar( CITV_MOREX, targetRegion->GetRegionNum() );
+											s->sysmessage( 550 );
+											targetRegion->TellMembers( 551, mChar->GetName().c_str() ); // Quickly, %s has stolen your treasured townstone!
+											regItems->Pop();
+											return;	// dump out
+										}
 									}
 								}
+								regItems->Pop();
 							}
-							regItems->Pop();
 						}
 					}
 					else

--- a/source/gumps.cpp
+++ b/source/gumps.cpp
@@ -2135,7 +2135,7 @@ void GumpDisplay::SetTitle( const std::string& newTitle )
 //o-----------------------------------------------------------------------------------------------o
 //|	Purpose		-	Sends to socket sock the data in one and two.  One is control, two is data
 //o-----------------------------------------------------------------------------------------------o
-void SendVecsAsGump( CSocket *sock, STRINGLIST& one, STRINGLIST& two, UI32 type, SERIAL serial )
+void SendVecsAsGump( CSocket *sock, std::vector<std::string>& one, std::vector<std::string>& two, UI32 type, SERIAL serial )
 {
 	CPSendGumpMenu toSend;
 	toSend.GumpID( type );

--- a/source/house.cpp
+++ b/source/house.cpp
@@ -90,11 +90,11 @@ void CreateHouseKey( CSocket *mSock, CChar *mChar, CMultiObj *house, UI16 houseI
 }
 
 //o-----------------------------------------------------------------------------------------------o
-//|	Function	-	void CreateHouseItems( CChar *mChar, STRINGLIST houseItems, CItem *house, UI16 houseID, SI16 x, SI16 y, SI08 z )
+//|	Function	-	void CreateHouseItems( CChar *mChar, std::vector<std::string> houseItems, CItem *house, UI16 houseID, SI16 x, SI16 y, SI08 z )
 //o-----------------------------------------------------------------------------------------------o
 //|	Purpose		-	Create items for house as defined in house.dfn
 //o-----------------------------------------------------------------------------------------------o
-void CreateHouseItems( CChar *mChar, STRINGLIST houseItems, CItem *house, UI16 houseID, SI16 x, SI16 y, SI08 z )
+void CreateHouseItems( CChar *mChar, std::vector<std::string> houseItems, CItem *house, UI16 houseID, SI16 x, SI16 y, SI08 z )
 {
 	std::string tag, data, UTag;
 	ScriptSection *HouseItem = nullptr;
@@ -450,7 +450,7 @@ void BuildHouse( CSocket *mSock, UI08 houseEntry )
 
 	SI16 sx = 0, sy = 0, cx = 0, cy = 0, bx = 0, by = 0;
 	SI08 cz = 7;
-	STRINGLIST houseItems;
+	std::vector<std::string> houseItems;
 	houseItems.resize( 0 );
 	bool itemsWillDecay = false;
 	bool isBoat			= false;

--- a/source/house.cpp
+++ b/source/house.cpp
@@ -14,6 +14,8 @@
 
 #include "ObjectFactory.h"
 
+using namespace std::string_literals ;
+
 bool CreateBoat( CSocket *s, CBoatObj *b, UI08 id2, UI08 boattype );
 
 //o-----------------------------------------------------------------------------------------------o
@@ -97,10 +99,9 @@ void CreateHouseItems( CChar *mChar, STRINGLIST houseItems, CItem *house, UI16 h
 	std::string tag, data, UTag;
 	ScriptSection *HouseItem = nullptr;
 	CItem *hItem = nullptr;
-	STRINGLIST_CITERATOR hiIter;
-	for( hiIter = houseItems.begin(); hiIter != houseItems.end(); ++hiIter )//Loop through the HOUSE_ITEMs
+	for( auto &hiIter :houseItems )//Loop through the HOUSE_ITEMs
 	{
-		std::string sect = "HOUSE ITEM " + (*hiIter);
+		std::string sect = "HOUSE ITEM "s + hiIter;
 		HouseItem = FileLookup->FindEntry( sect, house_def );
 		if( HouseItem != nullptr )
 		{

--- a/source/items.cpp
+++ b/source/items.cpp
@@ -813,7 +813,7 @@ CItem *cItem::CreateRandomItem( CItem *mCont, const std::string& sItemList, cons
 
 			int amountToSpawn = 1;
 			std::string k = "";
-			STRINGLIST csecs;
+			auto csecs = std::vector<std::string>();
 			if( itemEntryToSpawn != -1 )
 			{
 				// If an entry has been selected based on weights, use that

--- a/source/items.cpp
+++ b/source/items.cpp
@@ -1555,10 +1555,9 @@ void cItem::CheckEquipment( CChar *p )
 					i->SetCont( nullptr );
 					i->SetLocation( p );
 
-					SOCKLIST nearbyChars = FindNearbyPlayers( p );
-					for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-					{
-						p->SendWornItems( (*cIter) );
+					auto nearbyChars = FindNearbyPlayers( p );
+					for( auto &mSock:nearbyChars ){
+						p->SendWornItems( mSock );
 					}
 					pSock->sysmessage( 1604, itemname.c_str() ); // You are not strong enough to keep %s equipped!
 					Effects->itemSound( pSock, i );

--- a/source/lineofsight.cpp
+++ b/source/lineofsight.cpp
@@ -606,37 +606,36 @@ bool LineOfSight( CSocket *mSock, CChar *mChar, SI16 destX, SI16 destY, SI08 des
 	UI16 itemCount		= 0;
 
 	// We already have to run through all the collisions in this function, so lets just check and push the ID rather than coming back to it later.
-	REGIONLIST nearbyRegions = MapRegion->PopulateList( startX, startY, worldNumber );
-	for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
+	auto nearbyRegions = MapRegion->PopulateList( startX, startY, worldNumber );
+	for( auto &MapArea : nearbyRegions)
 	{
-		CMapRegion *MapArea = (*rIter);
-		if( MapArea == nullptr )	// no valid region
-			continue;
-		GenericList< CItem * > *regItems = MapArea->GetItemList();
-		regItems->Push();
-		for( CItem *toCheck = regItems->First(); !regItems->Finished(); toCheck = regItems->Next() )
-		{
-			if( !ValidateObject( toCheck ) || toCheck->GetInstanceID() != instanceID )
-				continue;
-
-			// If item toCheck is at the exact same spot as the target location, it should not block LoS.
-			if( toCheck->GetX() == destX && toCheck->GetY() == destY && toCheck->GetZ() == destZ )
-				continue;
-
-			const UI16 idToPush = DynamicCanBlock( toCheck, collisions, collisioncount, distX, distY, x1, x2, y1, y2, dz );
-			if( idToPush != INVALIDID )
+		if (MapArea != nullptr){
+			GenericList< CItem * > *regItems = MapArea->GetItemList();
+			regItems->Push();
+			for( CItem *toCheck = regItems->First(); !regItems->Finished(); toCheck = regItems->Next() )
 			{
-				CTile& itemToCheck = Map->SeekTile( idToPush );
-				losItemList[itemCount].Height(itemToCheck.Height());
-				losItemList[itemCount].SetID( idToPush );
-				losItemList[itemCount].Flags( itemToCheck.Flags() );
-
-				++itemCount;
-				if( itemCount >= LOSXYMAX )	// don't overflow
-					break;
+				if( !ValidateObject( toCheck ) || toCheck->GetInstanceID() != instanceID )
+					continue;
+				
+				// If item toCheck is at the exact same spot as the target location, it should not block LoS.
+				if( toCheck->GetX() == destX && toCheck->GetY() == destY && toCheck->GetZ() == destZ )
+					continue;
+				
+				const UI16 idToPush = DynamicCanBlock( toCheck, collisions, collisioncount, distX, distY, x1, x2, y1, y2, dz );
+				if( idToPush != INVALIDID )
+				{
+					CTile& itemToCheck = Map->SeekTile( idToPush );
+					losItemList[itemCount].Height(itemToCheck.Height());
+					losItemList[itemCount].SetID( idToPush );
+					losItemList[itemCount].Flags( itemToCheck.Flags() );
+					
+					++itemCount;
+					if( itemCount >= LOSXYMAX )	// don't overflow
+						break;
+				}
 			}
+			regItems->Pop();
 		}
-		regItems->Pop();
 	}
 
 	for( i = 0; i < collisioncount; ++i )

--- a/source/magic.cpp
+++ b/source/magic.cpp
@@ -1456,31 +1456,29 @@ bool splReveal( CSocket *sock, CChar *caster, SI16 x, SI16 y, SI08 z, SI08 curSp
 		//If the caster has a Magery of 26.1 (min to cast reveal w/ scroll), range  radius is
 		//5 tiles, if magery is maxed out at 100.0 (except for gms I suppose), range is 20
 
-		REGIONLIST nearbyRegions = MapRegion->PopulateList( caster );
-		for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
-		{
-			CMapRegion *MapArea = (*rIter);
-			if( MapArea == nullptr )	// no valid region
-				continue;
-			GenericList< CChar * > *regChars = MapArea->GetCharList();
-			regChars->Push();
-			for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
-			{
-				if( !ValidateObject( tempChar ) || tempChar->GetInstanceID() != caster->GetInstanceID() )
-					continue;
-				if( tempChar->GetVisible() == VT_TEMPHIDDEN || tempChar->GetVisible() == VT_INVISIBLE )
+		auto nearbyRegions = MapRegion->PopulateList( caster );
+		for( auto &MapArea: nearbyRegions ){
+			if (MapArea != nullptr){
+				GenericList< CChar * > *regChars = MapArea->GetCharList();
+				regChars->Push();
+				for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
 				{
-					point3 difference = ( tempChar->GetLocation() - point3( x, y, z ) );
-					if( difference.MagSquared() <= ( range * range ) ) // char to reveal is within radius or range
+					if( !ValidateObject( tempChar ) || tempChar->GetInstanceID() != caster->GetInstanceID() )
+						continue;
+					if( tempChar->GetVisible() == VT_TEMPHIDDEN || tempChar->GetVisible() == VT_INVISIBLE )
 					{
-						tempChar->ExposeToView();
-						CMagicStat temp = Magic->spells[48].StaticEffect();
-						if( temp.Effect() != INVALIDID )
-							Effects->PlayStaticAnimation( tempChar, temp.Effect(), temp.Speed(), temp.Loop() );
+						point3 difference = ( tempChar->GetLocation() - point3( x, y, z ) );
+						if( difference.MagSquared() <= ( range * range ) ) // char to reveal is within radius or range
+						{
+							tempChar->ExposeToView();
+							CMagicStat temp = Magic->spells[48].StaticEffect();
+							if( temp.Effect() != INVALIDID )
+								Effects->PlayStaticAnimation( tempChar, temp.Effect(), temp.Speed(), temp.Loop() );
+						}
 					}
 				}
+				regChars->Pop();
 			}
-			regChars->Pop();
 		}
 		if( Magic->spells[48].Effect() != INVALIDID )
 			Effects->PlaySound( sock, Magic->spells[48].Effect(), true );
@@ -1765,33 +1763,31 @@ bool AreaAffectSpell( CSocket *sock, CChar *caster, void (*trgFunc)( MAGIC_AREA_
 
 	Magic->BoxSpell( sock, caster, x1, x2, y1, y2, z1, z2 );
 
-	REGIONLIST nearbyRegions = MapRegion->PopulateList( caster );
-	for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
-	{
-		CMapRegion *MapArea = (*rIter);
-		if( MapArea == nullptr )	// no valid region
-			continue;
-		GenericList< CChar * > *regChars = MapArea->GetCharList();
-		regChars->Push();
-		for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
-		{
-			if( !ValidateObject( tempChar ) || tempChar->GetInstanceID() != caster->GetInstanceID() )
-				continue;
-
-			if( tempChar->GetX() >= x1 && tempChar->GetX() <= x2 && tempChar->GetY() >= y1 && tempChar->GetY() <= y2 &&
-			   tempChar->GetZ() >= z1 && tempChar->GetZ() <= z2 && ( isOnline( (*tempChar) ) || tempChar->IsNpc() ) )
+	auto nearbyRegions = MapRegion->PopulateList( caster );
+	for( auto &MapArea:nearbyRegions ){
+		if (MapArea != nullptr){
+			GenericList< CChar * > *regChars = MapArea->GetCharList();
+			regChars->Push();
+			for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
 			{
-				if( tempChar == caster || LineOfSight( sock, caster, tempChar->GetX(), tempChar->GetY(), ( tempChar->GetZ() + 15 ), WALLS_CHIMNEYS + DOORS + FLOORS_FLAT_ROOFING, false  ) || caster->IsGM() )
+				if( !ValidateObject( tempChar ) || tempChar->GetInstanceID() != caster->GetInstanceID() )
+					continue;
+				
+				if( tempChar->GetX() >= x1 && tempChar->GetX() <= x2 && tempChar->GetY() >= y1 && tempChar->GetY() <= y2 &&
+				   tempChar->GetZ() >= z1 && tempChar->GetZ() <= z2 && ( isOnline( (*tempChar) ) || tempChar->IsNpc() ) )
 				{
-					//Store target candidates in targetList
-					targetList.push_back( tempChar );
-					//trgFunc( caster, tempChar, curSpell, targCount );
+					if( tempChar == caster || LineOfSight( sock, caster, tempChar->GetX(), tempChar->GetY(), ( tempChar->GetZ() + 15 ), WALLS_CHIMNEYS + DOORS + FLOORS_FLAT_ROOFING, false  ) || caster->IsGM() )
+					{
+						//Store target candidates in targetList
+						targetList.push_back( tempChar );
+						//trgFunc( caster, tempChar, curSpell, targCount );
+					}
+					else if( sock != nullptr )
+						sock->sysmessage( 688 );
 				}
-				else if( sock != nullptr )
-					sock->sysmessage( 688 );
 			}
+			regChars->Pop();
 		}
-		regChars->Pop();
 	}
 
 	// Iterate through list of valid targets, do damage
@@ -3167,35 +3163,33 @@ void cMagic::MagicTrap( CChar *s, CItem *i )
 		Effects->PlaySound( i, 0x0207 );
 
 		// Find nearby players and apply damage to them?
-		REGIONLIST nearbyRegions = MapRegion->PopulateList( s );
-		for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
-		{
-			CMapRegion *MapArea = (*rIter);
-			if( MapArea == nullptr )	// no valid region
-				continue;
-			GenericList< CChar * > *regChars = MapArea->GetCharList();
-			regChars->Push();
-			for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
-			{
-				if( !ValidateObject( tempChar ) || tempChar->GetInstanceID() != s->GetInstanceID() || tempChar->GetSerial() == s->GetSerial() )
-					continue;
-
-				if( objInRange( tempChar, i, DIST_NEARBY ) )
+		auto nearbyRegions = MapRegion->PopulateList( s );
+		for( auto &MapArea: nearbyRegions ){
+			if (MapArea != nullptr){
+				GenericList< CChar * > *regChars = MapArea->GetCharList();
+				regChars->Push();
+				for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
 				{
-					if( CheckResist( nullptr, tempChar, 4 ) )
-						MagicDamage( tempChar, i->GetTempVar( CITV_MOREZ, 2 ) / 2, s, HEAT );
-					else
-						MagicDamage( tempChar, i->GetTempVar( CITV_MOREZ, 2 ), s, HEAT );
-
-					// Reveal hidden players impacted by the explosion
-					if( tempChar->GetVisible() == VT_TEMPHIDDEN || tempChar->GetVisible() == VT_INVISIBLE )
+					if( !ValidateObject( tempChar ) || tempChar->GetInstanceID() != s->GetInstanceID() || tempChar->GetSerial() == s->GetSerial() )
+						continue;
+					
+					if( objInRange( tempChar, i, DIST_NEARBY ) )
 					{
-						tempChar->ExposeToView();
+						if( CheckResist( nullptr, tempChar, 4 ) )
+							MagicDamage( tempChar, i->GetTempVar( CITV_MOREZ, 2 ) / 2, s, HEAT );
+						else
+							MagicDamage( tempChar, i->GetTempVar( CITV_MOREZ, 2 ), s, HEAT );
+						
+						// Reveal hidden players impacted by the explosion
+						if( tempChar->GetVisible() == VT_TEMPHIDDEN || tempChar->GetVisible() == VT_INVISIBLE )
+						{
+							tempChar->ExposeToView();
+						}
 					}
+					
 				}
-
+				regChars->Pop();
 			}
-			regChars->Pop();
 		}
 	}
 

--- a/source/msgboard.cpp
+++ b/source/msgboard.cpp
@@ -329,14 +329,13 @@ void MsgBoardWritePost( std::ofstream& mFile, const msgBoardPost_st& msgBoardPos
 	// Write number of lines in post as next byte, and
 	// then loop through each line
 	mFile.write( (const char *)&msgBoardPost.Lines, 1 );
-	STRINGLIST_CITERATOR lIter;
-	for( lIter = msgBoardPost.msgBoardLine.begin(); lIter != msgBoardPost.msgBoardLine.end(); ++lIter )
+	for( auto &lIter : msgBoardPost.msgBoardLine)
 	{
 		// Write length of line as next byte, and
 		// then write the line as next X bytes
-		const UI08 lineSize = static_cast<UI08>((*lIter).size());
+		const UI08 lineSize = static_cast<UI08>(lIter.size());
 		mFile.write( (const char *)&lineSize, 1 );
-		mFile.write( (*lIter).c_str(), lineSize );
+		mFile.write( lIter.c_str(), lineSize );
 	}
 
 	// Finally, add actual post serial to 4 bytes of buffer, and write buffer to file
@@ -394,10 +393,8 @@ SERIAL MsgBoardWritePost( msgBoardPost_st& msgBoardPost, const std::string& file
 	const UI08 posterSize	= static_cast<UI08>(msgBoardPost.PosterLen);
 	const UI08 subjSize		= static_cast<UI08>(msgBoardPost.SubjectLen);
 	UI16 totalSize			= static_cast<UI16>(15 + posterSize + subjSize + timeSize);
-	STRINGLIST_CITERATOR lIter;
-	for( lIter = msgBoardPost.msgBoardLine.begin(); lIter != msgBoardPost.msgBoardLine.end(); ++lIter )
-	{
-		totalSize += 1 + static_cast<UI16>( ( *lIter ).size() );
+	for( auto &lIter : msgBoardPost.msgBoardLine){
+		totalSize += 1 + static_cast<UI16>( lIter.size() );
 	}
 
 	msgBoardPost.Size			= totalSize;

--- a/source/msgboard.cpp
+++ b/source/msgboard.cpp
@@ -579,7 +579,7 @@ bool MsgBoardReadPost( std::ifstream& file, msgBoardPost_st& msgBoardPost, SERIA
 			file.read( buffer, 1 );
 			file.read( tmpLine, buffer[0]);
 
-			// Stuff contents of tmpLine into msgBoardLine STRINGLIST in msgBoardPost struct, then add null terminator
+			// Stuff contents of tmpLine into msgBoardLine std::vector<std::string> in msgBoardPost struct, then add null terminator
 			msgBoardPost.msgBoardLine.push_back( tmpLine );
 			msgBoardPost.msgBoardLine[msgBoardPost.msgBoardLine.size()-1] += '\0';
 		}

--- a/source/msgboard.h
+++ b/source/msgboard.h
@@ -42,7 +42,7 @@ struct msgBoardPost_st
 	UI32 ParentSerial;
 	UI08 Toggle;
 
-	STRINGLIST msgBoardLine;
+	std::vector<std::string> msgBoardLine;
 
 	msgBoardPost_st() : Serial( 0 ), Size( 0 ), PosterLen( 0 ), SubjectLen( 0 ), DateLen( 0 ), Lines( 0 ), ParentSerial( 0 ), Toggle( 0 )
 	{

--- a/source/network.h
+++ b/source/network.h
@@ -242,14 +242,15 @@ private:
 	std::map< UI16, UI16 >			packetOverloads;
 	std::vector< FirewallEntry >	slEntries;
 	SI32					a_socket;
-	SOCKLIST				connClients, loggedInClients;
+	std::vector< CSocket * >	connClients, loggedInClients;
 
 	struct sockaddr_in		client_addr;
 
 	size_t					peakConnectionCount;
-
-	std::vector< SOCKLIST_ITERATOR >	connIteratorBackup, loggIteratorBackup;
-	SOCKLIST_ITERATOR					currConnIter, currLoggIter;
+	//*************************************************************************
+	// OMG, saving iterators again, will look into this as we unwind all the includes
+	std::vector< std::vector< CSocket * >::iterator >	connIteratorBackup, loggIteratorBackup;
+	std::vector< CSocket * >::iterator					currConnIter, currLoggIter;
 
 	void		LoadFirewallEntries( void );
 	void		GetMsg( UOXSOCKET s );

--- a/source/pcmanage.cpp
+++ b/source/pcmanage.cpp
@@ -741,7 +741,7 @@ bool CPICreateCharacter::Handle( void )
 				locationNumber = clientFlags;
 
 			// Fetch player's chosen start location
-			LPSTARTLOCATION toGo = cwmWorldState->ServerData()->ServerLocation( locationNumber );
+			auto toGo = cwmWorldState->ServerData()->ServerLocation( locationNumber );
 
 			CServerData *sd = cwmWorldState->ServerData();
 			size_t serverCount = sd->NumServerLocations();

--- a/source/regions.cpp
+++ b/source/regions.cpp
@@ -687,25 +687,25 @@ MapResource_st * CMapHandler::GetResource( SI16 x, SI16 y, UI08 worldNum )
 }
 
 //o-----------------------------------------------------------------------------------------------o
-//|	Function	-	REGIONLIST PopulateList( CBaseObject *mObj )
+//|	Function	-	auto PopulateList( CBaseObject *mObj ) ->std::vector< CMapRegion * >
 //|	Date		-	Unknown
 //o-----------------------------------------------------------------------------------------------o
 //|	Purpose		-	Creates a list of nearby MapRegions based on the object provided
 //o-----------------------------------------------------------------------------------------------o
-REGIONLIST CMapHandler::PopulateList( CBaseObject *mObj )
+auto CMapHandler::PopulateList( CBaseObject *mObj ) -> std::vector< CMapRegion * >
 {
 	return PopulateList( mObj->GetX(), mObj->GetY(), mObj->WorldNumber() );
 }
 
 //o-----------------------------------------------------------------------------------------------o
-//|	Function	-	REGIONLIST PopulateList( SI16 x, SI16 y, UI08 worldNumber )
+//|	Function	-	auto PopulateList( SI16 x, SI16 y, UI08 worldNumber )->std::vector< CMapRegion * >
 //|	Date		-	Unknown
 //o-----------------------------------------------------------------------------------------------o
 //|	Purpose		-	Creates a list of nearby MapRegions based on the coordinates provided
 //o-----------------------------------------------------------------------------------------------o
-REGIONLIST CMapHandler::PopulateList( SI16 x, SI16 y, UI08 worldNumber )
+auto CMapHandler::PopulateList( SI16 x, SI16 y, UI08 worldNumber )->std::vector< CMapRegion * >
 {
-	REGIONLIST nearbyRegions;
+	std::vector< CMapRegion * > nearbyRegions;
 	const SI16 xOffset	= MapRegion->GetGridX( x );
 	const SI16 yOffset	= MapRegion->GetGridY( y );
 	for( SI08 counter1 = -1; counter1 <= 1; ++counter1 )

--- a/source/regions.h
+++ b/source/regions.h
@@ -113,8 +113,8 @@ public:
 	SI16		GetGridX( SI16 x );
 	SI16		GetGridY( SI16 y );
 
-	REGIONLIST	PopulateList( SI16 x, SI16 y, UI08 worldNumber );
-	REGIONLIST	PopulateList( CBaseObject *mObj );
+	auto	PopulateList( SI16 x, SI16 y, UI08 worldNumber ) ->std::vector< CMapRegion * >;
+	auto	PopulateList( CBaseObject *mObj ) ->std::vector< CMapRegion * >;
 
 	CMapWorld *	GetMapWorld( UI08 worldNum );
 

--- a/source/skills.cpp
+++ b/source/skills.cpp
@@ -1469,10 +1469,8 @@ void cSkills::doStealing( CSocket *s, CChar *mChar, CChar *npc, CItem *item )
 			if( npcSock != nullptr )
 				npcSock->sysmessage( temp );
 
-			SOCKLIST nearbyChars = FindNearbyPlayers( mChar );
-			for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-			{
-				CSocket *iSock = (*cIter);
+			auto nearbyChars = FindNearbyPlayers( mChar );
+			for( auto &iSock:nearbyChars ){
 				CChar *iChar = iSock->CurrcharObj();
 				if( iSock != s && ( RandomNum( 10, 20 ) == 17 || ( RandomNum( 0, 1 ) == 1 && iChar->GetIntelligence() >= mChar->GetIntelligence() ) ) )
 				{
@@ -1599,47 +1597,46 @@ void cSkills::CreateTrackingMenu( CSocket *s, UI16 m )
 	line = tag + " " + data;
 	toSend.Question( line );
 
-	REGIONLIST nearbyRegions = MapRegion->PopulateList( mChar );
-	for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
-	{
-		CMapRegion *MapArea = (*rIter);
-		if( MapArea == nullptr )	// no valid region
-			continue;
-		GenericList< CChar * > *regChars = MapArea->GetCharList();
-		regChars->Push();
-		for( CChar *tempChar = regChars->First(); !regChars->Finished() && MaxTrackingTargets < cwmWorldState->ServerData()->TrackingMaxTargets(); tempChar = regChars->Next() )
-		{
-			if( !ValidateObject( tempChar ) || tempChar->GetInstanceID() != mChar->GetInstanceID() )
-				continue;
-			id = tempChar->GetID();
-			if( ( !cwmWorldState->creatures[id].IsHuman() || creatureType == CT_PERSON ) && ( !cwmWorldState->creatures[id].IsAnimal() || creatureType == CT_ANIMAL ) )
+	auto nearbyRegions = MapRegion->PopulateList( mChar );
+	for( auto &MapArea: nearbyRegions ){
+		
+		if( MapArea!= nullptr ){	// no valid region
+			GenericList< CChar * > *regChars = MapArea->GetCharList();
+			regChars->Push();
+			for( CChar *tempChar = regChars->First(); !regChars->Finished() && MaxTrackingTargets < cwmWorldState->ServerData()->TrackingMaxTargets(); tempChar = regChars->Next() )
 			{
-				const bool cmdLevelCheck = ( isOnline( (*tempChar) ) && ( mChar->GetCommandLevel() >= tempChar->GetCommandLevel() ) );
-				if( tempChar != mChar && objInRange( tempChar, mChar, distance ) && !tempChar->IsDead() && ( cmdLevelCheck || tempChar->IsNpc() ) )
+				if( !ValidateObject( tempChar ) || tempChar->GetInstanceID() != mChar->GetInstanceID() )
+					continue;
+				id = tempChar->GetID();
+				if( ( !cwmWorldState->creatures[id].IsHuman() || creatureType == CT_PERSON ) && ( !cwmWorldState->creatures[id].IsAnimal() || creatureType == CT_ANIMAL ) )
 				{
-					mChar->SetTrackingTargets( tempChar, MaxTrackingTargets );
-					++MaxTrackingTargets;
-
-					SI32 dirMessage = 898;
-					switch( Movement->Direction( mChar, tempChar->GetX(), tempChar->GetY() ) )
+					const bool cmdLevelCheck = ( isOnline( (*tempChar) ) && ( mChar->GetCommandLevel() >= tempChar->GetCommandLevel() ) );
+					if( tempChar != mChar && objInRange( tempChar, mChar, distance ) && !tempChar->IsDead() && ( cmdLevelCheck || tempChar->IsNpc() ) )
 					{
-						case NORTH:		dirMessage = 890;	break;
-						case NORTHWEST:	dirMessage = 891;	break;
-						case NORTHEAST:	dirMessage = 892;	break;
-						case SOUTH:		dirMessage = 893;	break;
-						case SOUTHWEST:	dirMessage = 894;	break;
-						case SOUTHEAST:	dirMessage = 895;	break;
-						case WEST:		dirMessage = 896;	break;
-						case EAST:		dirMessage = 897;	break;
-						default:		dirMessage = 898;	break;
+						mChar->SetTrackingTargets( tempChar, MaxTrackingTargets );
+						++MaxTrackingTargets;
+						
+						SI32 dirMessage = 898;
+						switch( Movement->Direction( mChar, tempChar->GetX(), tempChar->GetY() ) )
+						{
+							case NORTH:		dirMessage = 890;	break;
+							case NORTHWEST:	dirMessage = 891;	break;
+							case NORTHEAST:	dirMessage = 892;	break;
+							case SOUTH:		dirMessage = 893;	break;
+							case SOUTHWEST:	dirMessage = 894;	break;
+							case SOUTHEAST:	dirMessage = 895;	break;
+							case WEST:		dirMessage = 896;	break;
+							case EAST:		dirMessage = 897;	break;
+							default:		dirMessage = 898;	break;
+						}
+						std::string tempName = getNpcDictName( tempChar );
+						line = tempName + " " + Dictionary->GetEntry( dirMessage, mLang );
+						toSend.AddResponse( cwmWorldState->creatures[id].Icon(), 0, line );
 					}
-					std::string tempName = getNpcDictName( tempChar );
-					line = tempName + " " + Dictionary->GetEntry( dirMessage, mLang );
-					toSend.AddResponse( cwmWorldState->creatures[id].Icon(), 0, line );
 				}
 			}
+			regChars->Pop();
 		}
-		regChars->Pop();
 	}
 
 	if( MaxTrackingTargets == 0 )
@@ -1837,36 +1834,36 @@ void cSkills::AnvilTarget( CSocket *s, CItem& item, miningData *oreType )
 	VALIDATESOCKET( s );
 	CChar *mChar = s->CurrcharObj();
 
-	REGIONLIST nearbyRegions = MapRegion->PopulateList( mChar );
-	for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
-	{
-		CMapRegion *MapArea = (*rIter);
-		if( MapArea == nullptr )	// no valid region
-			continue;
-		GenericList< CItem * > *regItems = MapArea->GetItemList();
-		regItems->Push();
-		for( CItem *tempItem = regItems->First(); !regItems->Finished(); tempItem = regItems->Next() )
-		{
-			if( !ValidateObject( tempItem ) || tempItem->GetInstanceID() != mChar->GetInstanceID() )
-				continue;
-			if( tempItem->GetID() == 0x0FAF || tempItem->GetID() == 0x0FB0 )
+	auto nearbyRegions = MapRegion->PopulateList( mChar );
+	for( auto &MapArea:nearbyRegions ){
+		
+		if( MapArea != nullptr ){	// no valid region
+			
+			GenericList< CItem * > *regItems = MapArea->GetItemList();
+			regItems->Push();
+			for( CItem *tempItem = regItems->First(); !regItems->Finished(); tempItem = regItems->Next() )
 			{
-				if( objInRange( mChar, tempItem, DIST_NEARBY ) )
+				if( !ValidateObject( tempItem ) || tempItem->GetInstanceID() != mChar->GetInstanceID() )
+					continue;
+				if( tempItem->GetID() == 0x0FAF || tempItem->GetID() == 0x0FB0 )
 				{
-					UI32 getAmt = GetItemAmount( mChar, item.GetID(), item.GetColour(), item.GetTempVar( CITV_MORE ));
-					if( getAmt == 0 )
+					if( objInRange( mChar, tempItem, DIST_NEARBY ) )
 					{
-						s->sysmessage( 980, oreType->name.c_str() ); // You don't have enough %s ingots to make anything.
+						UI32 getAmt = GetItemAmount( mChar, item.GetID(), item.GetColour(), item.GetTempVar( CITV_MORE ));
+						if( getAmt == 0 )
+						{
+							s->sysmessage( 980, oreType->name.c_str() ); // You don't have enough %s ingots to make anything.
+							regItems->Pop();
+							return;
+						}
+						NewMakeMenu( s, oreType->makemenu, BLACKSMITHING );
 						regItems->Pop();
 						return;
 					}
-					NewMakeMenu( s, oreType->makemenu, BLACKSMITHING );
-					regItems->Pop();
-					return;
 				}
 			}
+			regItems->Pop();
 		}
-		regItems->Pop();
 	}
 	s->sysmessage( 981 ); // The anvil is too far away.
 }
@@ -1913,10 +1910,8 @@ bool cSkills::LoadMiningData( void )
 		{
 			rvalue = true;
 			ScriptSection *individualOre = nullptr;
-			STRINGLIST_CITERATOR toCheck;
-			for( toCheck = oreNameList.begin(); toCheck != oreNameList.end(); ++toCheck )
-			{
-				std::string oreName = (*toCheck);
+			for( auto &oreName : oreNameList ){
+				
 				individualOre = FileLookup->FindEntry( oreName, skills_def );
 				if( individualOre != nullptr )
 				{

--- a/source/skills.cpp
+++ b/source/skills.cpp
@@ -1898,7 +1898,7 @@ bool cSkills::LoadMiningData( void )
 	bool rvalue = false;
 	if( oreList != nullptr )
 	{
-		STRINGLIST oreNameList;
+		auto  oreNameList = std::vector<std::string>();
 		std::string tag;
 		std::string data;
 		std::string UTag;

--- a/source/sound.cpp
+++ b/source/sound.cpp
@@ -28,10 +28,9 @@ void cEffects::PlaySound( CSocket *mSock, UI16 soundID, bool allHear )
 
 	if( allHear )
 	{
-		SOCKLIST nearbyChars = FindNearbyPlayers( mChar );
-		for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-		{
-			(*cIter)->Send( &toSend );
+		auto nearbyChars = FindNearbyPlayers( mChar );
+		for( auto &mSock:nearbyChars ){
+			mSock->Send( &toSend );
 		}
 	}
 	mSock->Send( &toSend );
@@ -51,10 +50,10 @@ void cEffects::PlaySound( CBaseObject *baseObj, UI16 soundID, bool allHear )
 
 	if( allHear )
 	{
-		SOCKLIST nearbyChars = FindPlayersInVisrange( baseObj );
-		for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-		{
-			(*cIter)->Send( &toSend );
+		auto nearbyChars = FindPlayersInVisrange( baseObj );
+		for( auto &mSock:nearbyChars){
+		
+			mSock->Send( &toSend );
 		}
 	}
 	else
@@ -187,25 +186,24 @@ void cEffects::PlayBGSound( CSocket& mSock, CChar& mChar )
 	std::vector< CChar * > inrange;
 	inrange.reserve( 11 );
 
-	REGIONLIST nearbyRegions = MapRegion->PopulateList( (&mChar) );
-	for( REGIONLIST_CITERATOR rIter = nearbyRegions.begin(); rIter != nearbyRegions.end(); ++rIter )
-	{
-		CMapRegion *MapArea = (*rIter);
-		if( MapArea == nullptr )	// no valid region
-			continue;
-		GenericList< CChar * > *regChars = MapArea->GetCharList();
-		regChars->Push();
-		for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
-		{
-			if( !ValidateObject( tempChar ) || tempChar->isFree() || tempChar->GetInstanceID() != mChar.GetInstanceID() )
-				continue;
-			if( tempChar->IsNpc() && !tempChar->IsDead() && !tempChar->IsAtWar() && charInRange( (&mChar), tempChar ) )
-				inrange.push_back( tempChar );
-
-			if( inrange.size() == 11 )
-				break;
+	auto nearbyRegions = MapRegion->PopulateList( (&mChar) );
+	for( auto &MapArea:nearbyRegions ){
+		
+		if( MapArea != nullptr ){	// no valid region
+			GenericList< CChar * > *regChars = MapArea->GetCharList();
+			regChars->Push();
+			for( CChar *tempChar = regChars->First(); !regChars->Finished(); tempChar = regChars->Next() )
+			{
+				if( !ValidateObject( tempChar ) || tempChar->isFree() || tempChar->GetInstanceID() != mChar.GetInstanceID() )
+					continue;
+				if( tempChar->IsNpc() && !tempChar->IsDead() && !tempChar->IsAtWar() && charInRange( (&mChar), tempChar ) )
+					inrange.push_back( tempChar );
+				
+				if( inrange.size() == 11 )
+					break;
+			}
+			regChars->Pop();
 		}
-		regChars->Pop();
 	}
 
 	UI16 basesound = 0;
@@ -470,10 +468,9 @@ void cEffects::playTileSound( CChar *mChar, CSocket *mSock )
 		if( mSock == nullptr && ValidateObject( mChar ) )
 		{
 			// It's an NPC!
-			SOCKLIST nearbyChars = FindNearbyPlayers( mChar );
-			for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-			{
-				PlaySound( (*cIter), soundID, false );
+			auto nearbyChars = FindNearbyPlayers( mChar );
+			for( auto &sock: nearbyChars){
+				PlaySound( sock, soundID, false );
 			}
 			return;
 		}

--- a/source/speech.cpp
+++ b/source/speech.cpp
@@ -113,12 +113,12 @@ void ClilocMessage( CSocket *mSock, CBaseObject *srcObj, SpeechType speechType, 
 		else if( speechType == EMOTE || speechType == ASCIIEMOTE )
 			searchDistance = DIST_INRANGE;
 
-		SOCKLIST nearbyChars = FindNearbyPlayers( srcObj, searchDistance );
-		for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
+		auto nearbyChars = FindNearbyPlayers( srcObj, searchDistance );
+		for( auto &sock:nearbyChars )
 		{
-			if( sendSock && (*cIter) == mSock )
+			if( sendSock && (sock == mSock) )
 				sendSock = false;
-			(*cIter)->Send( &toSend );
+			sock->Send( &toSend );
 		}
 	}
 
@@ -382,7 +382,7 @@ bool CPITalkRequest::Handle( void )
 			}
 			tSock->Send( txtToSend );
 
-			SOCKLIST nearbyChars;
+			std::vector<CSocket*> nearbyChars;
 			// Distance at which other players can hear the speech depends on speech-type
 			if(( Type() == WHISPER || Type() == ASCIIWHISPER ) && !mChar->IsGM() && !mChar->IsCounselor() )
 				nearbyChars = FindNearbyPlayers( mChar, 1 );
@@ -393,9 +393,8 @@ bool CPITalkRequest::Handle( void )
 			else
 				nearbyChars = FindNearbyPlayers( mChar );
 
-			for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-			{
-				CSocket *tSock	= (*cIter);
+			for( auto &tSock:nearbyChars){
+			
 				CChar *tChar	= tSock->CurrcharObj();
 				if( mChar != tChar )
 				{
@@ -515,10 +514,8 @@ void CSpeechQueue::SayIt( CSpeechEntry& toSay )
 				break;
 			if( ValidateObject( thisItem ) && thisItem->GetCont() != nullptr )	// not on ground, can't guarantee speech
 				break;
-			SOCKLIST nearbyChars = FindPlayersInVisrange( thisObj );
-			for( SOCKLIST_CITERATOR cIter = nearbyChars.begin(); cIter != nearbyChars.end(); ++cIter )
-			{
-				mSock = (*cIter);
+			auto nearbyChars = FindPlayersInVisrange( thisObj );
+			for( auto &mSock : nearbyChars){
 				CChar *mChar = mSock->CurrcharObj();
 				if( ValidateObject( mChar ) )
 				{

--- a/source/typedefs.h
+++ b/source/typedefs.h
@@ -6,7 +6,6 @@
 
 #ifdef __NEED_VALIST__
 using va_list = void* ;
-
 #endif
 
 #if PLATFORM != WINDOWS
@@ -23,6 +22,7 @@ return;	\
 #define VALIDATESOCKET( s ) if( s == nullptr ) \
 return;
 #endif
+
 using R32 = float ;
 using R64 = double ;
 using UI08 = std::uint8_t ; // 0 to 255
@@ -34,48 +34,38 @@ using UI32 = std::uint32_t ; // 0 to 4294967295
 using SI64 = std::int64_t ; // -9223372036854775808 to 9223372036854775807
 using UI64 = std::uint64_t ; // 0 to 18446744073709551615
 
-using GENDER = std::uint8_t ;
-using LIGHTLEVEL = std::uint8_t ;
-using COLDLEVEL = std::uint8_t ;
-using HEATLEVEL = std::uint8_t ;
-using SECONDS = std::uint8_t ;
-using ARMORCLASS = std::uint8_t ;
-using RACEREL = std::uint8_t ;
-using RANGE = std::int8_t ;
-using RACEID = std::uint16_t ;
-using COLOUR = std::uint16_t ;
-using SKILLVAL = std::uint16_t ;
-using weathID = std::uint16_t ;
-using GUILDID = std::int16_t ;
-using TIMERVAL = std::uint32_t ;
-using SERIAL = std::uint32_t ;
+using GENDER	= std::uint8_t ;
+using LIGHTLEVEL	= std::uint8_t ;
+using COLDLEVEL	= std::uint8_t ;
+using HEATLEVEL	= std::uint8_t ;
+using SECONDS	= std::uint8_t ;
+using ARMORCLASS	= std::uint8_t ;
+using RACEREL	= std::uint8_t ;
+using RANGE		= std::int8_t ;
+using RACEID	= std::uint16_t ;
+using COLOUR	= std::uint16_t ;
+using SKILLVAL	= std::uint16_t ;
+using weathID	= std::uint16_t ;
+using GUILDID	= std::int16_t ;
+using TIMERVAL	= std::uint32_t ;
+using SERIAL	= std::uint32_t ;
 
 #if defined(_WIN32)
-using UOXSOCKET = std::uint32_t ;
+using UOXSOCKET	= std::uint32_t ;
 #else
-using UOXSOCKET = std::int32_t ;
+using UOXSOCKET	= std::int32_t ;
 #endif
 
-constexpr auto INVALIDSERIAL = std::uint32_t(0xFFFFFFFF) ;
+constexpr auto INVALIDSERIAL	= std::uint32_t(0xFFFFFFFF) ;
 constexpr auto BASEITEMSERIAL = std::uint32_t(0x40000000) ;
-constexpr auto INVALIDID = std::uint16_t(0xFFFF);
-constexpr auto INVALIDCOLOUR = std::uint16_t(0xFFFF);
+constexpr auto INVALIDID	= std::uint16_t(0xFFFF);
+constexpr auto INVALIDCOLOUR	= std::uint16_t(0xFFFF);
 
-class CMapRegion ;
-using REGIONLIST = std::vector< CMapRegion * >	;
-using REGIONLIST_ITERATOR = std::vector< CMapRegion * >::iterator;
-using REGIONLIST_CITERATOR = std::vector< CMapRegion * >::const_iterator;
-//typedef std::vector< CMapRegion * >						REGIONLIST;
-//typedef std::vector< CMapRegion * >::iterator			REGIONLIST_ITERATOR;
-//typedef std::vector< CMapRegion * >::const_iterator		REGIONLIST_CITERATOR;
 
 typedef std::vector< CSocket * >						SOCKLIST;
 typedef std::vector< CSocket * >::iterator				SOCKLIST_ITERATOR;
-typedef std::vector< CSocket * >::const_iterator		SOCKLIST_CITERATOR;
 //
 typedef std::vector< std::string >						STRINGLIST;
-typedef std::vector< std::string >::iterator			STRINGLIST_ITERATOR;
-typedef std::vector< std::string >::const_iterator		STRINGLIST_CITERATOR;
 //
 typedef std::vector< SERIAL >							SERLIST;
 typedef std::vector< SERIAL >::iterator					SERLIST_ITERATOR;
@@ -112,39 +102,39 @@ typedef void (TargetFunc)( CSocket *s );
 // Max values
 constexpr auto MAX_NAME = std::uint8_t(128); // Several areas where we pass a character name will be restricted by packet size to 30 characters.
 								// Higher MAX_NAME values do, however, work for items - and are in some cases required (magic item names, for instance). Seems to still work for regular-length names if I increase it, but we might consider splitting this into character/item-specific somehow?
-constexpr auto MAX_TITLE = std::uint8_t(60);
-constexpr auto MAX_VISRANGE = std::uint8_t(18);
-constexpr auto MAXPOSTS = std::uint8_t(128); // Maximum number of posts on a messageboard
-constexpr auto MAX_STACK = std::uint16_t(0xFFFF);
-constexpr auto MAXBUFFER = std::uint16_t(4096); // Buffer Size (For socket operations)
-constexpr auto ILLEGAL_Z = std::int8_t(-128) ;
+constexpr auto MAX_TITLE	= std::uint8_t(60);
+constexpr auto MAX_VISRANGE	= std::uint8_t(18);
+constexpr auto MAXPOSTS		= std::uint8_t(128); // Maximum number of posts on a messageboard
+constexpr auto MAX_STACK	= std::uint16_t(0xFFFF);
+constexpr auto MAXBUFFER	= std::uint16_t(4096); // Buffer Size (For socket operations)
+constexpr auto ILLEGAL_Z	= std::int8_t(-128) ;
 
 // Offsets for Gump menu's (Relates to menus.dfn)
-constexpr auto ITEMMENUOFFSET = 256 ;
-constexpr auto TRACKINGMENUOFFSET = 4096 ;
-constexpr auto POLYMORPHMENUOFFSET = 8192 ;
-constexpr auto JSGUMPMENUOFFSET = 16384 ;
+constexpr auto ITEMMENUOFFSET		= 256 ;
+constexpr auto TRACKINGMENUOFFSET	= 4096 ;
+constexpr auto POLYMORPHMENUOFFSET	= 8192 ;
+constexpr auto JSGUMPMENUOFFSET	= 16384 ;
 
 
-constexpr auto NORTH = std::uint8_t(0x00) ;
-constexpr auto NORTHEAST = std::uint8_t(0x01) ;
-constexpr auto EAST = std::uint8_t(0x02) ;
-constexpr auto SOUTHEAST = std::uint8_t(0x03) ;
-constexpr auto SOUTH = std::uint8_t(0x04) ;
-constexpr auto SOUTHWEST = std::uint8_t(0x05) ;
-constexpr auto WEST = std::uint8_t(0x06) ;
-constexpr auto NORTHWEST = std::uint8_t(0x07) ;
-constexpr auto UNKNOWNDIR = std::uint8_t(0xFF) ;
+constexpr auto NORTH		= std::uint8_t(0x00) ;
+constexpr auto NORTHEAST	= std::uint8_t(0x01) ;
+constexpr auto EAST		= std::uint8_t(0x02) ;
+constexpr auto SOUTHEAST	= std::uint8_t(0x03) ;
+constexpr auto SOUTH		= std::uint8_t(0x04) ;
+constexpr auto SOUTHWEST	= std::uint8_t(0x05) ;
+constexpr auto WEST		= std::uint8_t(0x06) ;
+constexpr auto NORTHWEST	= std::uint8_t(0x07) ;
+constexpr auto UNKNOWNDIR	= std::uint8_t(0xFF) ;
 
 
 // Line Of Sight
-constexpr auto ITEM_TYPE_CHOICES = 6 ;
-constexpr auto TREES_BUSHES = 1 ; // Trees and other large vegetaion in the way
-constexpr auto WALLS_CHIMNEYS = 2 ; // Walls, chimineys, ovens, etc... in the way
-constexpr auto DOORS = 4 ; // Doors in the way
-constexpr auto ROOFING_SLANTED = 8 ; // So can't tele onto slanted roofs, basically
-constexpr auto FLOORS_FLAT_ROOFING = 16 ; // For attacking between floors
-constexpr auto LAVA_WATER = 32 ; // Don't know what all to use this for yet
+constexpr auto ITEM_TYPE_CHOICES	= 6 ;
+constexpr auto TREES_BUSHES		= 1 ; // Trees and other large vegetaion in the way
+constexpr auto WALLS_CHIMNEYS		= 2 ; // Walls, chimineys, ovens, etc... in the way
+constexpr auto DOORS			= 4 ; // Doors in the way
+constexpr auto ROOFING_SLANTED	= 8 ; // So can't tele onto slanted roofs, basically
+constexpr auto FLOORS_FLAT_ROOFING	= 16 ; // For attacking between floors
+constexpr auto LAVA_WATER		= 32 ; // Don't know what all to use this for yet
 
 #endif
 

--- a/source/typedefs.h
+++ b/source/typedefs.h
@@ -62,10 +62,6 @@ constexpr auto INVALIDID	= std::uint16_t(0xFFFF);
 constexpr auto INVALIDCOLOUR	= std::uint16_t(0xFFFF);
 
 
-typedef std::vector< CSocket * >						SOCKLIST;
-typedef std::vector< CSocket * >::iterator				SOCKLIST_ITERATOR;
-//
-typedef std::vector< std::string >						STRINGLIST;
 //
 typedef std::vector< SERIAL >							SERLIST;
 typedef std::vector< SERIAL >::iterator					SERLIST_ITERATOR;

--- a/source/typedefs.h
+++ b/source/typedefs.h
@@ -2,13 +2,15 @@
 #define __UOXTYPES_H
 
 #include <unordered_map>
+#include <cstdint>
 
 #ifdef __NEED_VALIST__
-typedef void *  va_list;
+using va_list = void* ;
+
 #endif
 
 #if PLATFORM != WINDOWS
-#define MAX_PATH			268
+constexpr auto MAX_PATH	= 268 ;
 #endif
 
 #if defined( _DEBUG )
@@ -21,47 +23,51 @@ return;	\
 #define VALIDATESOCKET( s ) if( s == nullptr ) \
 return;
 #endif
+using R32 = float ;
+using R64 = double ;
+using UI08 = std::uint8_t ; // 0 to 255
+using SI08 = std::int8_t ; // -128 to 127
+using SI16 = std::int16_t ; // -32768 to 32767
+using UI16 = std::uint16_t; // 0 to 65535
+using SI32 = std::int32_t ; // -2147483648 to 2147483647
+using UI32 = std::uint32_t ; // 0 to 4294967295
+using SI64 = std::int64_t ; // -9223372036854775808 to 9223372036854775807
+using UI64 = std::uint64_t ; // 0 to 18446744073709551615
 
-typedef float				R32;
-typedef double				R64;
-typedef unsigned char		UI08; // 0 to 255
-typedef signed char			SI08; // -128 to 127
-typedef unsigned short int	UI16; // 0 to 65535
-typedef signed short int	SI16; // -32768 to 32767
-typedef unsigned int		UI32; // 0 to 4294967295
-typedef signed int			SI32; // -2147483648 to 2147483647
-typedef unsigned long long	UI64; // 0 to 18446744073709551615
-typedef signed long long	SI64; // -9223372036854775808 to 9223372036854775807
+using GENDER = std::uint8_t ;
+using LIGHTLEVEL = std::uint8_t ;
+using COLDLEVEL = std::uint8_t ;
+using HEATLEVEL = std::uint8_t ;
+using SECONDS = std::uint8_t ;
+using ARMORCLASS = std::uint8_t ;
+using RACEREL = std::uint8_t ;
+using RANGE = std::int8_t ;
+using RACEID = std::uint16_t ;
+using COLOUR = std::uint16_t ;
+using SKILLVAL = std::uint16_t ;
+using weathID = std::uint16_t ;
+using GUILDID = std::int16_t ;
+using TIMERVAL = std::uint32_t ;
+using SERIAL = std::uint32_t ;
 
-typedef UI08		GENDER;
-typedef UI08		LIGHTLEVEL;
-typedef UI08		COLDLEVEL;
-typedef UI08		HEATLEVEL;
-typedef UI08		SECONDS;
-typedef UI08		ARMORCLASS;
-typedef SI08		RACEREL;
-typedef SI08		RANGE;
-typedef UI16		RACEID;
-typedef UI16		COLOUR;
-typedef UI16		SKILLVAL;
-typedef UI16		weathID;
-typedef SI16		GUILDID;
-typedef UI32		TIMERVAL;
 #if defined(_WIN32)
-typedef UI32		UOXSOCKET;
+using UOXSOCKET = std::uint32_t ;
 #else
-typedef SI32		UOXSOCKET;
+using UOXSOCKET = std::int32_t ;
 #endif
-typedef UI32		SERIAL;
 
-const SERIAL		INVALIDSERIAL		= 0xFFFFFFFF;
-const UI16			INVALIDID			= 0xFFFF;
-const UI16			INVALIDCOLOUR		= 0xFFFF;
-const SERIAL		BASEITEMSERIAL		= 0x40000000;
+constexpr auto INVALIDSERIAL = std::uint32_t(0xFFFFFFFF) ;
+constexpr auto BASEITEMSERIAL = std::uint32_t(0x40000000) ;
+constexpr auto INVALIDID = std::uint16_t(0xFFFF);
+constexpr auto INVALIDCOLOUR = std::uint16_t(0xFFFF);
 
-typedef std::vector< CMapRegion * >						REGIONLIST;
-typedef std::vector< CMapRegion * >::iterator			REGIONLIST_ITERATOR;
-typedef std::vector< CMapRegion * >::const_iterator		REGIONLIST_CITERATOR;
+class CMapRegion ;
+using REGIONLIST = std::vector< CMapRegion * >	;
+using REGIONLIST_ITERATOR = std::vector< CMapRegion * >::iterator;
+using REGIONLIST_CITERATOR = std::vector< CMapRegion * >::const_iterator;
+//typedef std::vector< CMapRegion * >						REGIONLIST;
+//typedef std::vector< CMapRegion * >::iterator			REGIONLIST_ITERATOR;
+//typedef std::vector< CMapRegion * >::const_iterator		REGIONLIST_CITERATOR;
 
 typedef std::vector< CSocket * >						SOCKLIST;
 typedef std::vector< CSocket * >::iterator				SOCKLIST_ITERATOR;
@@ -97,64 +103,48 @@ typedef std::unordered_map< UI16, CSpawnRegion * >::const_iterator	SPAWNMAP_CITE
 typedef std::map< UI16, CTownRegion * >						TOWNMAP;
 typedef std::map< UI16, CTownRegion * >::const_iterator		TOWNMAP_CITERATOR;
 
+
 typedef void (TargetFunc)( CSocket *s );
 
-// December 27, 2000
-typedef struct __STARTLOCATIONDATA__
-{
-	__STARTLOCATIONDATA__()
-	{
-		memset( this, 0x00, sizeof( __STARTLOCATIONDATA__ ) );
-	}
-	char	oldTown[31];
-	char	oldDescription[31];
-	char	newTown[32];
-	char	newDescription[32];
-	SI16	x;
-	SI16	y;
-	SI16	z;
-	SI16	worldNum;
-	UI16	instanceID;
-	UI32	clilocDesc;
 
-} STARTLOCATION, *LPSTARTLOCATION;
 //	 	-	End
 
 // Max values
-const UI08 MAX_NAME		= 128;	// Several areas where we pass a character name will be restricted by packet size to 30 characters.
+constexpr auto MAX_NAME = std::uint8_t(128); // Several areas where we pass a character name will be restricted by packet size to 30 characters.
 								// Higher MAX_NAME values do, however, work for items - and are in some cases required (magic item names, for instance). Seems to still work for regular-length names if I increase it, but we might consider splitting this into character/item-specific somehow?
-const UI08 MAX_TITLE	= 60;
-const UI16 MAX_STACK	= 0xFFFF;
-const UI08 MAX_VISRANGE	= 18;
-const UI16 MAXBUFFER	= 4096;	// Buffer Size (For socket operations)
-const UI08 MAXPOSTS		= 128;	// Maximum number of posts on a messageboard
-
-const SI08 ILLEGAL_Z	= -128;
+constexpr auto MAX_TITLE = std::uint8_t(60);
+constexpr auto MAX_VISRANGE = std::uint8_t(18);
+constexpr auto MAXPOSTS = std::uint8_t(128); // Maximum number of posts on a messageboard
+constexpr auto MAX_STACK = std::uint16_t(0xFFFF);
+constexpr auto MAXBUFFER = std::uint16_t(4096); // Buffer Size (For socket operations)
+constexpr auto ILLEGAL_Z = std::int8_t(-128) ;
 
 // Offsets for Gump menu's (Relates to menus.dfn)
-#define ITEMMENUOFFSET		256
-#define TRACKINGMENUOFFSET	4096
-#define POLYMORPHMENUOFFSET 8192
-#define JSGUMPMENUOFFSET	16384
+constexpr auto ITEMMENUOFFSET = 256 ;
+constexpr auto TRACKINGMENUOFFSET = 4096 ;
+constexpr auto POLYMORPHMENUOFFSET = 8192 ;
+constexpr auto JSGUMPMENUOFFSET = 16384 ;
 
-const UI08 NORTH		= 0x00;
-const UI08 NORTHEAST	= 0x01;
-const UI08 EAST			= 0x02;
-const UI08 SOUTHEAST	= 0x03;
-const UI08 SOUTH		= 0x04;
-const UI08 SOUTHWEST	= 0x05;
-const UI08 WEST			= 0x06;
-const UI08 NORTHWEST	= 0x07;
-const UI08 UNKNOWNDIR	= 0xFF;
+
+constexpr auto NORTH = std::uint8_t(0x00) ;
+constexpr auto NORTHEAST = std::uint8_t(0x01) ;
+constexpr auto EAST = std::uint8_t(0x02) ;
+constexpr auto SOUTHEAST = std::uint8_t(0x03) ;
+constexpr auto SOUTH = std::uint8_t(0x04) ;
+constexpr auto SOUTHWEST = std::uint8_t(0x05) ;
+constexpr auto WEST = std::uint8_t(0x06) ;
+constexpr auto NORTHWEST = std::uint8_t(0x07) ;
+constexpr auto UNKNOWNDIR = std::uint8_t(0xFF) ;
+
 
 // Line Of Sight
-#define ITEM_TYPE_CHOICES		6
-const UI08 TREES_BUSHES			= 1;	// Trees and other large vegetaion in the way
-const UI08 WALLS_CHIMNEYS		= 2;	// Walls, chimineys, ovens, etc... in the way
-const UI08 DOORS				= 4;	// Doors in the way
-const UI08 ROOFING_SLANTED		= 8;	// So can't tele onto slanted roofs, basically
-const UI08 FLOORS_FLAT_ROOFING	= 16;	// For attacking between floors
-const UI08 LAVA_WATER			= 32;	// Don't know what all to use this for yet
+constexpr auto ITEM_TYPE_CHOICES = 6 ;
+constexpr auto TREES_BUSHES = 1 ; // Trees and other large vegetaion in the way
+constexpr auto WALLS_CHIMNEYS = 2 ; // Walls, chimineys, ovens, etc... in the way
+constexpr auto DOORS = 4 ; // Doors in the way
+constexpr auto ROOFING_SLANTED = 8 ; // So can't tele onto slanted roofs, basically
+constexpr auto FLOORS_FLAT_ROOFING = 16 ; // For attacking between floors
+constexpr auto LAVA_WATER = 32 ; // Don't know what all to use this for yet
 
 #endif
 

--- a/source/wholist.h
+++ b/source/wholist.h
@@ -9,7 +9,7 @@ private:
 	bool		online;
 
 	SERLIST		whoMenuData;
-	STRINGLIST one, two;				// replacement for entries1, entries2
+	std::vector<std::string> one, two;				// replacement for entries1, entries2
 
 	void Update( void );				// force the list to update
 	void ResetUpdateFlag( void );

--- a/uox3.xcodeproj/project.pbxproj
+++ b/uox3.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		6452D32227D3A7CB00E5AFB4 /* osunique.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6452D32127D3A7CB00E5AFB4 /* osunique.cpp */; };
 		648AF6EE27CFEFA3009327DE /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 648AF6ED27CFEF94009327DE /* libz.tbd */; platformFilters = (maccatalyst, macos, ); };
-		648AF6F027CFF108009327DE /* libjs.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 648AF6EF27CFF0F5009327DE /* libjs.a */; };
 		648AF79627CFF2CD009327DE /* cConsole.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 648AF6F627CFF2CC009327DE /* cConsole.cpp */; };
 		648AF79727CFF2CD009327DE /* dist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 648AF6F727CFF2CC009327DE /* dist.cpp */; };
 		648AF79827CFF2CD009327DE /* calcfuncs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 648AF6FA27CFF2CC009327DE /* calcfuncs.cpp */; };
@@ -90,6 +89,7 @@
 		648AF7E327CFF2CD009327DE /* weight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 648AF79127CFF2CD009327DE /* weight.cpp */; };
 		648AF7E427CFF2CD009327DE /* effect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 648AF79327CFF2CD009327DE /* effect.cpp */; };
 		648AF7E527CFF2CD009327DE /* speech.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 648AF79527CFF2CD009327DE /* speech.cpp */; };
+		64EAC33128484667004BF08B /* libjs32.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 64EAC33028484655004BF08B /* libjs32.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -270,6 +270,7 @@
 		648AF79327CFF2CD009327DE /* effect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = effect.cpp; sourceTree = "<group>"; };
 		648AF79427CFF2CD009327DE /* cSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cSocket.h; sourceTree = "<group>"; };
 		648AF79527CFF2CD009327DE /* speech.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = speech.cpp; sourceTree = "<group>"; };
+		64EAC33028484655004BF08B /* libjs32.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libjs32.a; path = ../spidermonkey/libjs32.a; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -277,8 +278,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				648AF6F027CFF108009327DE /* libjs.a in Frameworks */,
 				648AF6EE27CFEFA3009327DE /* libz.tbd in Frameworks */,
+				64EAC33128484667004BF08B /* libjs32.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -305,6 +306,7 @@
 		648AF6EC27CFEF94009327DE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				64EAC33028484655004BF08B /* libjs32.a */,
 				648AF6EF27CFF0F5009327DE /* libjs.a */,
 				648AF6ED27CFEF94009327DE /* libz.tbd */,
 			);


### PR DESCRIPTION
modernizes typdef.h. 
The goal is to also unwind all the interdependences so every file doesn't include every file.  That slows down build time significantly.  However, it is so interwoven we have to remove to some things, so all the typedef for lists, created class object dependencies.  So we need to remove all those from typedef, so we can unwind in a logical way.  Then, if we want to make typedefs for list, we can look at that then.  Ideally, as we modernize, we may discover we don't need most of the typedefs (auto is great, and modern looping is great).

This was based on the last pull request.