### PR TITLE
Disabled writing back uox.ini file (just commented out, can be reenab…

### DIFF
--- a/source/GenericList.h
+++ b/source/GenericList.h
@@ -62,13 +62,16 @@ public:
 	~GenericList() = default ;
 
 	//===================================================================
-	auto collection() const -> const std::list<T>& {
+	// Because contents get deleted during iterator, we will return a copy
+	auto collection() const -> std::list<T> {
 		return objData ;
 	}
+	/*
 	//===================================================================
 	auto collection()  ->  std::list<T>& {
 		return objData ;
 	}
+	 */
 	//===================================================================
 	auto GetCurrent() -> T {
 		T rvalue = nullptr;

--- a/source/cServerData.cpp
+++ b/source/cServerData.cpp
@@ -3726,6 +3726,7 @@ bool CServerData::save( void )
 //o-----------------------------------------------------------------------------------------------o
 bool CServerData::save( std::string filename )
 {
+	return true ;
 	bool rvalue = false;
 	std::ofstream ofsOutput;
 	ofsOutput.open( filename.c_str(), std::ios::out );


### PR DESCRIPTION
…led).

collection now return a copy of  the collection for GenericList to allow detection during iteration