### PR TITLE
FreeBSD build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,14 @@ Join the [UOX3 Discord](https://discord.gg/uBAXxhF) for support and/or a quick c
 
 First step, open a new terminal and enter the commands below:
 
-1) (Linux) `sudo apt install git` - This will install git if not already installed (Ubuntu/Debian-based Linux variants). If you're using a non-Debian flavour of Linux, use the default package manager that comes with it to install git instead.
-1) (macOS) `xcode-select --install` - This will install git if not already installed, along with required make and gcc tools
+1) Install prerequisites:
+
+   * **Linux:** `sudo apt install git` - This will install git if not already installed (Ubuntu/Debian-based Linux variants). If you're using a non-Debian flavour of Linux, use the default package manager that comes with it to install git instead.
+
+   * **macOS:** `xcode-select --install` - This will install git if not already installed, along with required make and gcc tools
+
+   * **FreeBSD:** `pkg install git gmake` - This will install git and gmake if not already installed. Alternatively, build `git` and `gmake` via ports if desired.
+
 2) `git clone https://github.com/UOX3DevTeam/UOX3.git` - This will clone the stable master branch of the UOX3 git repository into a subdirectory of the current directory you're in, named UOX3. The latest verified compatible version of SpiderMonkey (v1.7.0) is also included, as well as a minimal set of files required to compile zlib-1.2.11.
 
 <details>
@@ -48,7 +54,7 @@ First step, open a new terminal and enter the commands below:
 
 ## Step 2: Compile UOX3
 <details>
-  <summary>Compiling with GNU Make and GCC (v9.x and above)</summary>
+  <summary>Compiling with GNU Make and GCC (v9.x and above) or Clang</summary>
 
 You'll need a couple tools before you can compile UOX3 on Linux, like **GNU Make** (*v4.2.1* or higher recommended) and **gcc** (*v9.x* or higher recommended). Install these through your favourite package manager or through your flavour of Linux' variant of the following terminal command (example specific to Debian/Ubuntu Linux flavours):
 
@@ -79,13 +85,18 @@ Once these are in place, navigate to the **UOX3** project folder in your termina
   If you don't wish to rely on the automake.sh script, but want control over the process yourself, follow these steps (same as what automake.sh does):
 
   - `cd spidermonkey`
-  - `make -f Makefile.ref DEFINES=-DHAVE_VA_LIST_AS_ARRAY CC=gcc`
   ### Linux ###
+  - `make -f Makefile.ref DEFINES=-DHAVE_VA_LIST_AS_ARRAY CC=gcc`
   - `ar -r libjs32.a Linux_All_DBG.OBJ/*.o`
   - `cp Linux_All_DBG.OBJ/jsautocfg.h ./`
   ### macOS ###
+  - `make -f Makefile.ref DEFINES=-DHAVE_VA_LIST_AS_ARRAY CC=gcc`
   - `ar rcs libjs32.a Darwin_DBG.OBJ/*.o`
   - `cp Darwin_DBG.OBJ/jsautocfg.h ./`
+  ### FreeBSD ###
+  - `gmake -f Makefile.ref DEFINES=-DHAVE_VA_LIST_AS_ARRAY CC=clang`
+  - `ar rcs libjs32.a FreeBSD_DBG.OBJ/*.o`
+  - `cp FreeBSD_DBG.OBJ/jsautocfg.h ./`
 
   *Next up, compile a static library of the included zlib package:*
 
@@ -97,7 +108,7 @@ Once these are in place, navigate to the **UOX3** project folder in your termina
   *At this point, now cd to the root UOX3 project directory and build UOX3:*
 
   - `cd ../source`
-  - `make`
+  - `make` (`gmake` under FreeBSD)
 
 </details>
 

--- a/automake.sh
+++ b/automake.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 echo "Building spidermonkey"
 cd spidermonkey
-make -f Makefile.ref DEFINES=-DHAVE_VA_LIST_AS_ARRAY CC=gcc
+if [ "$(uname)" = "FreeBSD" ]
+then
+  gmake -f Makefile.ref DEFINES=-DHAVE_VA_LIST_AS_ARRAY CC=clang
+else
+  make -f Makefile.ref DEFINES=-DHAVE_VA_LIST_AS_ARRAY CC=gcc
+fi
 
 if [ "$(uname)" = "Darwin" ]
 then
         # Mac OS X
         ar rcs libjs32.a Darwin_DBG.OBJ/*.o
         cp Darwin_DBG.OBJ/jsautocfg.h ./
+elif [ "$(uname)" = "FreeBSD" ]
+then
+        ar rcs libjs32.a FreeBSD_DBG.OBJ/*.o
+        cp FreeBSD_DBG.OBJ/jsautocfg.h ./
 elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]
 then
         # Linux
@@ -17,12 +26,17 @@ fi
 cd ../zlib
 echo "Bulding zlib"
 make distclean
-./configure 
-make 
+./configure
+make
 
 cd ../source
 echo "Building UOX3"
-make
+if [ "$(uname)" = "FreeBSD" ]
+then
+  gmake
+else
+  make
+fi
 cp uox3 ..
 cd ..
 echo "Done! You should now find the compiled uox3 binary in the root UOX3 project directory. Copy this binary to a separate directory dedicated to running your UOX3 shard, along with the contents of the UOX3/data directory, to avoid potential git conflicts and accidental overwriting of data when pulling UOX3 updates in the future."

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -44,7 +44,7 @@ add_library(uox
 		vendor.cpp
 		ObjectFactory.cpp
 		cItem.cpp
-		cplayeraction.cpp
+		cPlayerAction.cpp
 		pcmanage.cpp
 		weight.cpp
 		PartySystem.cpp

--- a/source/IP4Address.cpp
+++ b/source/IP4Address.cpp
@@ -28,6 +28,9 @@ constexpr auto MAX_TRIES = 3;
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 #include <netinet/in.h>
+#if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+  #include <sys/socket.h>  // AF_INET, SOCK_DGRAM, and struct sockaddr
+#endif
 #endif
 using namespace std::string_literals ;
 //=================================================================================

--- a/source/IP4Address.cpp
+++ b/source/IP4Address.cpp
@@ -28,9 +28,7 @@ constexpr auto MAX_TRIES = 3;
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 #include <netinet/in.h>
-#if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
-  #include <sys/socket.h>  // AF_INET, SOCK_DGRAM, and struct sockaddr
-#endif
+#include <sys/socket.h>
 #endif
 using namespace std::string_literals ;
 //=================================================================================

--- a/source/Makefile
+++ b/source/Makefile
@@ -1,8 +1,13 @@
-BASE		:= ..
-SPIDER		:= $(BASE)/spidermonkey
-ZLIB		:= $(BASE)/zlib
+BASE      := ..
+SPIDER    := $(BASE)/spidermonkey
+ZLIB      := $(BASE)/zlib
+PLATFORM  := $(shell uname)
 
-CXX			:= g++
+ifeq ($(PLATFORM),FreeBSD)
+CXX     := clang++
+else
+CXX     := g++
+endif
 CXXFLAGS	:= -std=c++17 -O2 -pthread -Wno-shift-negative-value
 LDFLAGS		:= -L$(SPIDER)  -ljs32 -L$(ZLIB) -lz
 TARGET		:= uox3

--- a/source/SEFunctions.cpp
+++ b/source/SEFunctions.cpp
@@ -3497,7 +3497,7 @@ JSBool SE_DeleteFile( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, jsv
 //o-----------------------------------------------------------------------------------------------o
 JSBool SE_GetServerSetting( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, jsval *rval )
 {
-	*rval = NULL;
+	*rval = reinterpret_cast<long>(nullptr);
 
 	if( argc != 1 )
 	{

--- a/spidermonkey/Makefile.in
+++ b/spidermonkey/Makefile.in
@@ -245,8 +245,8 @@ endif
 
 LDFLAGS		+= $(pathsubst -l%,$(NSPR_STATIC_PATH)/%.a,$(NSPR_LIBS))
 
-# BeOS and HP-UX do not require the extra linking of "-lm"
-ifeq (,$(filter BeOS HP-UX WINNT WINCE OpenVMS,$(OS_ARCH)))
+# BeOS, FreeBSD, and HP-UX do not require the extra linking of "-lm"
+ifeq (,$(filter BeOS FreeBSD HP-UX WINNT WINCE OpenVMS,$(OS_ARCH)))
 LDFLAGS		+= -lm
 endif
 

--- a/spidermonkey/Makefile.ref
+++ b/spidermonkey/Makefile.ref
@@ -87,7 +87,10 @@ CFLAGS          += $(OPTIMIZER) $(OS_CFLAGS) $(DEFINES) $(INCLUDES) $(XCFLAGS)
 LDFLAGS		= $(XLDFLAGS)
 
 ifndef NO_LIBM
+# BeOS, FreeBSD, and HP-UX do not require the extra linking of "-lm"
+ifeq (,$(filter BeOS FreeBSD HP-UX WINNT WINCE OpenVMS,$(OS_ARCH)))
 LDFLAGS += -lm
+endif
 endif
 
 # Prevent floating point errors caused by VC++ optimizations

--- a/spidermonkey/config.mk
+++ b/spidermonkey/config.mk
@@ -100,7 +100,11 @@ else
 ifeq ($(OS_ARCH),Darwin)
 OS_CONFIG      := Darwin
 else
-OS_CONFIG       := $(OS_ARCH)$(OS_OBJTYPE)$(OS_RELEASE)
+ifeq ($(OS_ARCH),FreeBSD)
+OS_CONFIG      := FreeBSD
+else
+OS_CONFIG      := $(OS_ARCH)$(OS_OBJTYPE)$(OS_RELEASE)
+endif
 endif
 endif
 endif

--- a/spidermonkey/config/FreeBSD.mk
+++ b/spidermonkey/config/FreeBSD.mk
@@ -1,0 +1,103 @@
+# -*- Mode: makefile -*-
+#
+# ***** BEGIN LICENSE BLOCK *****
+# Version: MPL 1.1/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Mozilla Public License Version
+# 1.1 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+# http://www.mozilla.org/MPL/
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+# for the specific language governing rights and limitations under the
+# License.
+#
+# The Original Code is Mozilla Communicator client code, released
+# March 31, 1998.
+#
+# The Initial Developer of the Original Code is
+# Netscape Communications Corporation.
+# Portions created by the Initial Developer are Copyright (C) 1998
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either the GNU General Public License Version 2 or later (the "GPL"), or
+# the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the MPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the MPL, the GPL or the LGPL.
+#
+# ***** END LICENSE BLOCK *****
+
+#
+# Config for all versions of Linux
+#
+
+CC = clang
+CCC = clang++
+CFLAGS +=  -Wall -Wno-format -fPIC -lm
+OS_CFLAGS = -DXP_UNIX -DSVR4 -DSYSV -D_BSD_SOURCE -DPOSIX_SOURCE -DHAVE_LOCALTIME_R
+
+RANLIB = echo
+MKSHLIB = $(LD) -shared $(XMKSHLIBOPTS)
+
+#.c.o:
+#      $(CC) -c -MD $*.d $(CFLAGS) $<
+
+CPU_ARCH = $(shell uname -m)
+# don't filter in x86-64 architecture
+ifneq (x86_64,$(CPU_ARCH))
+ifeq (86,$(findstring 86,$(CPU_ARCH)))
+CPU_ARCH = x86
+OS_CFLAGS+= -DX86_LINUX
+
+ifeq (gcc, $(CC))
+# if using gcc on x86, check version for opt bug
+# (http://bugzilla.mozilla.org/show_bug.cgi?id=24892)
+GCC_VERSION := $(shell gcc -v 2>&1 | grep version | awk '{ print $$3 }')
+GCC_LIST:=$(sort 2.91.66 $(GCC_VERSION) )
+
+ifeq (2.91.66, $(firstword $(GCC_LIST)))
+CFLAGS+= -DGCC_OPT_BUG
+endif
+endif
+endif
+endif
+
+GFX_ARCH = x
+
+OS_LIBS = -lc
+
+ASFLAGS += -x assembler-with-cpp
+
+
+ifeq ($(CPU_ARCH),alpha)
+
+# Ask the C compiler on alpha linux to let us work with denormalized
+# double values, which are required by the ECMA spec.
+
+OS_CFLAGS += -mieee
+endif
+
+# Use the editline library to provide line-editing support.
+JS_EDITLINE = 1
+
+ifeq ($(CPU_ARCH),x86_64)
+# Use VA_COPY() standard macro on x86-64
+# FIXME: better use it everywhere
+OS_CFLAGS += -DHAVE_VA_COPY -DVA_COPY=va_copy
+endif
+
+ifeq ($(CPU_ARCH),x86_64)
+# We need PIC code for shared libraries
+# FIXME: better patch rules.mk & fdlibm/Makefile*
+OS_CFLAGS += -DPIC -fPIC
+endif

--- a/zlib/configure
+++ b/zlib/configure
@@ -258,6 +258,7 @@ else
     uname=`(uname -sr || echo unknown) 2>/dev/null`
   fi
   case "$uname" in
+  FreeBSD*)  CFLAGS=${CFLAGS-"-O -fPIC"} ;;
   HP-UX*)    SFLAGS=${CFLAGS-"-O +z"}
              CFLAGS=${CFLAGS-"-O"}
 #            LDSHARED=${LDSHARED-"ld -b +vnocompatwarnings"}


### PR DESCRIPTION
### Proposed Changes:
- Fixed `cPlayerAction.cpp` case in `source/CMakeLists.txt` (was `cplayeraction.cpp`).
- Added FreeBSD build support for SpiderMonkey, zlib, and UOX3.
- Updated `README.md` with FreeBSD build instructions.
- Fixed the following compile error due to `NULL` being defined as `nullptr` (non-int type) and not `0` (zero):
 ```sh
 SEFunctions.cpp:3500:10: error: assigning to 'jsval' (aka 'long') from incompatible type 'nullptr_t'
        *rval = NULL;
 ```