### PR TITLE
Improve error handling around compile failures

### DIFF
--- a/automake.sh
+++ b/automake.sh
@@ -8,6 +8,12 @@ else
   make -f Makefile.ref DEFINES=-DHAVE_VA_LIST_AS_ARRAY CC=gcc
 fi
 
+$ev=$?
+if [ $ev -ne 0 ]; then
+  echo "Unable to build spidermonkey, cannot continue"
+  exit $ev
+fi
+
 if [ "$(uname)" = "Darwin" ]
 then
         # Mac OS X
@@ -23,11 +29,18 @@ then
         ar -r libjs32.a Linux_All_DBG.OBJ/*.o
         cp Linux_All_DBG.OBJ/jsautocfg.h ./
 fi
+
 cd ../zlib
 echo "Bulding zlib"
 make distclean
 ./configure
 make
+
+$ev=$?
+if [ $ev -ne 0 ]; then
+  echo "Unable to build zlib, cannot continue"
+  exit $ev
+fi
 
 cd ../source
 echo "Building UOX3"
@@ -37,6 +50,12 @@ then
 else
   make
 fi
-cp uox3 ..
+ev=$?
+if [ -f ./uox3 ]; then
+  cp uox3 ..
+  echo "Done! You should now find the compiled uox3 binary in the root UOX3 project directory. Copy this binary to a separate directory dedicated to running your UOX3 shard, along with the contents of the UOX3/data directory, to avoid potential git conflicts and accidental overwriting of data when pulling UOX3 updates in the future."
+else
+  echo "uox3 output not created!  Please review compile status"
+fi
 cd ..
-echo "Done! You should now find the compiled uox3 binary in the root UOX3 project directory. Copy this binary to a separate directory dedicated to running your UOX3 shard, along with the contents of the UOX3/data directory, to avoid potential git conflicts and accidental overwriting of data when pulling UOX3 updates in the future."
+exit $ev


### PR DESCRIPTION
Adds some logic to abort if spidermonkey or zlib fail to build.

Captures exit code of the main source build and ensures that it is the return value of the build process.  This should hopefully fix github actions passing when compile fails.