### PR TITLE
Fix for buying stuff from npc shopkeepers, and misc

### DIFF
--- a/source/Changelog.txt
+++ b/source/Changelog.txt
@@ -1,3 +1,10 @@
+13/11/2022 - Xuri
+	When buying items from NPC shopkeepers where the total cost is higher than the buy threshold set in uox.ini, UOX3 will now check the player's bankbox for gold first, then their backpack second, instead of just failing outright if bank didn't have the required amount
+	Minor cleanup of some UO era-specific code for better maintainability
+	Adjusted default light-settings in UOX.INI:
+		DUNGEONLIGHTLEVEL changed from 3 to 15
+		WORLDDARKLEVEL changed from 5 to 12
+
 12/11/2022 - Dragon Slayer
 	Added hair-only and beard-only variants of hair dyes
 	Added hair stylist vendors that sell all types of dye

--- a/source/cServerData.cpp
+++ b/source/cServerData.cpp
@@ -550,10 +550,10 @@ auto CServerData::ResetDefaults() -> void
 	SystemTimer( tSERVER_POTION, 10 );
 	ServerMoon( 0, 0 );
 	ServerMoon( 1, 0 );
-	DungeonLightLevel( 3 );
+	DungeonLightLevel( 15 );
 	WorldLightCurrentLevel( 0 );
 	WorldLightBrightLevel( 0 );
-	WorldLightDarkLevel( 5 );
+	WorldLightDarkLevel( 12 );
 
 	ServerNetRcvTimeout( 3 );
 	ServerNetSndTimeout( 3 );
@@ -4345,6 +4345,27 @@ auto CServerData::SaveIni() -> bool
 	return SaveIni( s );
 }
 
+// Map of era enums to era strings, used for conversion between the two types
+static const std::unordered_map<ExpansionRuleset, std::string> eraNames
+{
+	{ ER_T2A,	"t2a"s },
+	{ ER_UOR,	"uor"s },
+	{ ER_TD,	"td"s },
+	{ ER_LBR,	"lbr"s },
+	{ ER_PUB15, "pub15"s },
+	{ ER_AOS,	"aos"s },
+	{ ER_SE,	"se"s },
+	{ ER_ML,	"ml"s },
+	{ ER_SA,	"sa"s },
+	{ ER_HS,	"hs"s },
+	{ ER_TOL,	"tol"s }
+};
+
+//o------------------------------------------------------------------------------------------------o
+//|	Function	-	CServerData::EraEnumToString()
+//o------------------------------------------------------------------------------------------------o
+//|	Purpose		-	Pass an era enum in, get an era string back
+//o------------------------------------------------------------------------------------------------o
 auto CServerData::EraEnumToString( ExpansionRuleset eraEnum, bool coreEnum ) -> std::string
 {
 	std::string eraName = "pub15"; // default
@@ -4355,49 +4376,46 @@ auto CServerData::EraEnumToString( ExpansionRuleset eraEnum, bool coreEnum ) -> 
 	}
 	else
 	{
-		switch( eraEnum )
+		try
 		{
-			case ER_CORE:	eraName = "core";	break;
-			case ER_T2A:	eraName = "t2a";	break;
-			case ER_UOR:	eraName = "uor";	break;
-			case ER_TD:		eraName = "td";		break;
-			case ER_LBR:	eraName = "lbr";	break;
-			case ER_PUB15:	eraName = "pub15";	break;
-			case ER_AOS:	eraName = "aos";	break;
-			case ER_SE:		eraName = "se";		break;
-			case ER_ML:		eraName = "ml";		break;
-			case ER_SA:		eraName = "sa";		break;
-			case ER_HS:		eraName = "hs";		break;
-			case ER_TOL:	eraName = "tol";	break;
-			default:
-				break;
+			eraName = eraNames.at( eraEnum );
+		}
+		catch( const std::out_of_range &e )
+		{
+			Console.Error( oldstrutil::format( "Unknown era enum detected, exception thrown: %s", e.what() ));
 		}
 	}
 
 	return eraName;
 }
 
-auto CServerData::EraStringToEnum( std::string eraString ) ->ExpansionRuleset
+//o------------------------------------------------------------------------------------------------o
+//|	Function	-	CServerData::EraStringToEnum()
+//o------------------------------------------------------------------------------------------------o
+//|	Purpose		-	Pass an era string in, get an era enum back
+//o------------------------------------------------------------------------------------------------o
+auto CServerData::EraStringToEnum( const std::string &eraString ) -> ExpansionRuleset
 {
-	ExpansionRuleset eraEnum = ER_PUB15; // default
+	auto searchEra = oldstrutil::lower( eraString );
+	auto rValue = ER_PUB15; // Default era if specified era is not found
 
-	// Convert to lower case first
-	eraString = oldstrutil::lower( eraString );
+	if( searchEra == "core" )
+	{
+		// Inherit setting from CORESHARDERA setting
+		return static_cast<ExpansionRuleset>( ExpansionCoreShardEra() );
+	}
+	
+	// Look for string with era name in eras map
+	auto iter = std::find_if( eraNames.begin(), eraNames.end(), [&searchEra]( const std::pair<ExpansionRuleset, std::string> &value ) {
+		return searchEra == std::get<1>( value );
+	});
 
-	if( eraString == "core" )		{ eraEnum = static_cast<ExpansionRuleset>( ExpansionCoreShardEra() ); }
-	else if( eraString == "t2a" )	{ eraEnum = ER_T2A; }
-	else if( eraString == "uor" )	{ eraEnum = ER_UOR; }
-	else if( eraString == "td" )	{ eraEnum = ER_TD; }
-	else if( eraString == "lbr" )	{ eraEnum = ER_UOR; }
-	else if( eraString == "pub15" ) { eraEnum = ER_PUB15; }
-	else if( eraString == "aos" )	{ eraEnum = ER_AOS; }
-	else if( eraString == "se" )	{ eraEnum = ER_SE; }
-	else if( eraString == "ml" )	{ eraEnum = ER_ML; }
-	else if( eraString == "sa" )	{ eraEnum = ER_SA; }
-	else if( eraString == "hs" )	{ eraEnum = ER_HS; }
-	else if( eraString == "tol" )	{ eraEnum = ER_TOL; }
+	if( iter != eraNames.end() )
+	{
+		rValue = iter->first;
+	}
 
-	return eraEnum;
+	return rValue;
 }
 
 //o------------------------------------------------------------------------------------------------o

--- a/source/cServerData.h
+++ b/source/cServerData.h
@@ -474,7 +474,7 @@ public:
 	auto		SaveIni( const std::string &filename ) -> bool;
 
 	auto		EraEnumToString( ExpansionRuleset eraNum, bool coreEnum = false ) -> std::string;
-	auto		EraStringToEnum( std::string eraString ) ->ExpansionRuleset;
+	auto		EraStringToEnum( const std::string &eraString ) -> ExpansionRuleset;
 
 	auto ResetDefaults() -> void;
 	auto Startup() -> void;


### PR DESCRIPTION
- When buying items from NPC shopkeepers where the total cost is higher than the buy threshold set in uox.ini, UOX3 will now check the player's bankbox for gold first, then their backpack second, instead of just failing outright if bank didn't have the required amount 
- Minor cleanup of some UO era-specific code for better maintainability
- Adjusted default light-settings in UOX.INI:
	DUNGEONLIGHTLEVEL changed from 3 to 15
	WORLDDARKLEVEL changed from 5 to 12