### PR TITLE
Fix compile warnings (for 0.99.6-RC6/PR #176)

### DIFF
--- a/source/SEFunctions.cpp
+++ b/source/SEFunctions.cpp
@@ -1958,7 +1958,7 @@ JSBool SE_TriggerEvent( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, j
 //|	Notes		-	Takes 2 parameters, which is the script number to check and the
 //|					event name to check for
 //o------------------------------------------------------------------------------------------------o
-JSBool SE_DoesEventExist( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, jsval *rval )
+JSBool SE_DoesEventExist( JSContext *cx, [[maybe_unused]] JSObject *obj, uintN argc, jsval *argv, jsval *rval )
 {
 	if( argc != 2 )
 	{

--- a/source/UOXJSMethods.cpp
+++ b/source/UOXJSMethods.cpp
@@ -3975,7 +3975,7 @@ JSBool CGuild_AcceptRecruit( JSContext *cx, JSObject *obj, uintN argc, jsval *ar
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Checks if guild is at peace, i.e. not at war with any other guilds
 //o------------------------------------------------------------------------------------------------o
-JSBool CGuild_IsAtPeace( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, [[maybe_unused]] jsval *rval )
+JSBool CGuild_IsAtPeace( JSContext *cx, JSObject *obj, uintN argc, [[maybe_unused]] jsval *argv, [[maybe_unused]] jsval *rval )
 {
 	if( argc != 0 )
 	{
@@ -10988,7 +10988,7 @@ JSBool CRegion_GetOrePref( JSContext *cx, JSObject *obj, uintN argc, jsval *argv
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Get chance to find ore when mining in townregion
 //o------------------------------------------------------------------------------------------------o
-JSBool CRegion_GetOreChance( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, [[maybe_unused]] jsval *rval )
+JSBool CRegion_GetOreChance( JSContext *cx, JSObject *obj, uintN argc, [[maybe_unused]] jsval *argv, [[maybe_unused]] jsval *rval )
 {
 	if( argc != 0 )
 	{

--- a/source/UOXJSPropertyFuncs.cpp
+++ b/source/UOXJSPropertyFuncs.cpp
@@ -1566,7 +1566,7 @@ JSBool CCharacterProps_getProperty( JSContext *cx, JSObject *obj, jsval id, jsva
 				}
 			case CCP_ORIGNAME:
 			{
-				CSocket *tSock = nullptr;
+				[[maybe_unused]] CSocket *tSock = nullptr;
 
 				std::string mCharName = gPriv->GetOrgName();
 				std::string convertedString = oldstrutil::stringToWstringToString( mCharName );

--- a/source/ai.cpp
+++ b/source/ai.cpp
@@ -68,7 +68,7 @@ bool IsValidAttackTarget( CChar& mChar, CChar *cTarget )
 				// Young players are not valid targets for NPCs outside of dungeons
 				if( cwmWorldState->ServerData()->YoungPlayerSystem() && mChar.IsNpc() && !cTarget->IsNpc() && IsOnline(( *cTarget )) && cTarget->GetAccount().wFlags.test( AB_FLAGS_YOUNG ) && !cTarget->GetRegion()->IsDungeon() )
 				{
-					if( cTarget->GetSocket() && (cTarget->GetTimer( tCHAR_YOUNGMESSAGE ) <= cwmWorldState->GetUICurrentTime() || cwmWorldState->GetOverflow()) )
+					if( cTarget->GetSocket() && ( cTarget->GetTimer( tCHAR_YOUNGMESSAGE ) <= cwmWorldState->GetUICurrentTime() || cwmWorldState->GetOverflow() ))
 					{
 						cTarget->SetTimer( tCHAR_YOUNGMESSAGE, BuildTimeValue( static_cast<R32>( 120 ))); // Only send them the warning message once couple of minutes
 						cTarget->GetSocket()->SysMessage( 18734 ); // A monster looks at you menacingly but does not attack.  You would be under attack now if not for your status as a new citizen of Britannia.

--- a/source/ai.cpp
+++ b/source/ai.cpp
@@ -68,7 +68,7 @@ bool IsValidAttackTarget( CChar& mChar, CChar *cTarget )
 				// Young players are not valid targets for NPCs outside of dungeons
 				if( cwmWorldState->ServerData()->YoungPlayerSystem() && mChar.IsNpc() && !cTarget->IsNpc() && IsOnline(( *cTarget )) && cTarget->GetAccount().wFlags.test( AB_FLAGS_YOUNG ) && !cTarget->GetRegion()->IsDungeon() )
 				{
-					if( (cTarget->GetSocket() && cTarget->GetTimer( tCHAR_YOUNGMESSAGE ) <= cwmWorldState->GetUICurrentTime()) || cwmWorldState->GetOverflow() )
+					if( cTarget->GetSocket() && (cTarget->GetTimer( tCHAR_YOUNGMESSAGE ) <= cwmWorldState->GetUICurrentTime()) || cwmWorldState->GetOverflow()) )
 					{
 						cTarget->SetTimer( tCHAR_YOUNGMESSAGE, BuildTimeValue( static_cast<R32>( 120 ))); // Only send them the warning message once couple of minutes
 						cTarget->GetSocket()->SysMessage( 18734 ); // A monster looks at you menacingly but does not attack.  You would be under attack now if not for your status as a new citizen of Britannia.

--- a/source/ai.cpp
+++ b/source/ai.cpp
@@ -68,7 +68,7 @@ bool IsValidAttackTarget( CChar& mChar, CChar *cTarget )
 				// Young players are not valid targets for NPCs outside of dungeons
 				if( cwmWorldState->ServerData()->YoungPlayerSystem() && mChar.IsNpc() && !cTarget->IsNpc() && IsOnline(( *cTarget )) && cTarget->GetAccount().wFlags.test( AB_FLAGS_YOUNG ) && !cTarget->GetRegion()->IsDungeon() )
 				{
-					if( cTarget->GetSocket() && (cTarget->GetTimer( tCHAR_YOUNGMESSAGE ) <= cwmWorldState->GetUICurrentTime()) || cwmWorldState->GetOverflow()) )
+					if( cTarget->GetSocket() && (cTarget->GetTimer( tCHAR_YOUNGMESSAGE ) <= cwmWorldState->GetUICurrentTime() || cwmWorldState->GetOverflow()) )
 					{
 						cTarget->SetTimer( tCHAR_YOUNGMESSAGE, BuildTimeValue( static_cast<R32>( 120 ))); // Only send them the warning message once couple of minutes
 						cTarget->GetSocket()->SysMessage( 18734 ); // A monster looks at you menacingly but does not attack.  You would be under attack now if not for your status as a new citizen of Britannia.

--- a/source/ai.cpp
+++ b/source/ai.cpp
@@ -68,7 +68,7 @@ bool IsValidAttackTarget( CChar& mChar, CChar *cTarget )
 				// Young players are not valid targets for NPCs outside of dungeons
 				if( cwmWorldState->ServerData()->YoungPlayerSystem() && mChar.IsNpc() && !cTarget->IsNpc() && IsOnline(( *cTarget )) && cTarget->GetAccount().wFlags.test( AB_FLAGS_YOUNG ) && !cTarget->GetRegion()->IsDungeon() )
 				{
-					if( cTarget->GetSocket() && cTarget->GetTimer( tCHAR_YOUNGMESSAGE ) <= cwmWorldState->GetUICurrentTime() || cwmWorldState->GetOverflow() )
+					if( (cTarget->GetSocket() && cTarget->GetTimer( tCHAR_YOUNGMESSAGE ) <= cwmWorldState->GetUICurrentTime()) || cwmWorldState->GetOverflow() )
 					{
 						cTarget->SetTimer( tCHAR_YOUNGMESSAGE, BuildTimeValue( static_cast<R32>( 120 ))); // Only send them the warning message once couple of minutes
 						cTarget->GetSocket()->SysMessage( 18734 ); // A monster looks at you menacingly but does not attack.  You would be under attack now if not for your status as a new citizen of Britannia.

--- a/source/cAccountClass.h
+++ b/source/cAccountClass.h
@@ -105,13 +105,13 @@ public:
 	std::bitset<AB_FLAGS_ALL>	wFlags;
 	UI32						wTimeBan;
 	UI32						wFirstLogin;
-	UI32						wTotalPlayTime;
 	UI32						dwInGame;
 	UI32						dwLastIP;
 	bool						bChanged;
 	UI32						dwLastClientVer;
 	UI08						dwLastClientType;
 	UI08						dwLastClientVerShort;
+	UI32						wTotalPlayTime;
 	UI32						dwCharacters[7];
 	CChar *						lpCharacters[7];
 } CAccountBlock_st;

--- a/source/cBaseObject.h
+++ b/source/cBaseObject.h
@@ -95,8 +95,6 @@ protected:
 	SI16				karma;
 	SI16				kills;
 	UI16				subRegion;
-	//std::string			origin; // Stores expansion item originates from
-	UI08				origin; // Stores expansion item originates from
 
 	void			RemoveFromMulti( bool fireTrigger = true );
 	void			AddToMulti( bool fireTrigger = true );
@@ -108,6 +106,8 @@ protected:
 	SERIAL			tempContainerSerial;
 
 	bool			nameRequestActive;
+	//std::string	origin;	// Stores expansion item originates from
+	UI08			origin;	// Stores expansion item originates from
 
 	void			CopyData( CBaseObject *target );
 

--- a/source/cChar.cpp
+++ b/source/cChar.cpp
@@ -1126,7 +1126,7 @@ void CChar::SetPassive( bool newValue )
 //|	Purpose		-	Returns/Sets whether the character has stolen something in the last X minutes
 //|					since their last death
 //o------------------------------------------------------------------------------------------------o
-auto CChar::HasStolen() -> const bool
+auto CChar::HasStolen() -> bool
 {
 	return bools.test( BIT_HASSTOLEN );
 }
@@ -5851,7 +5851,7 @@ void CChar::SetCreatedOn( UI32 newValue )
 //o------------------------------------------------------------------------------------------------o
 //| Purpose		-	Gets/Sets/Updates play time (in minutes) of character since it was created
 //o------------------------------------------------------------------------------------------------o
-auto CChar::GetPlayTime() const -> const UI32
+auto CChar::GetPlayTime() const -> UI32
 {
 	UI32 rVal = 0;
 	if( IsValidPlayer() )

--- a/source/cChar.h
+++ b/source/cChar.h
@@ -238,7 +238,7 @@ protected:
 	UI08		PoisonStrength;
 	BodyType	bodyType;
 	UI32		lastMoveTime; 			// Timestamp for when character moved last
-	UI16		npcGuild;						// ID of NPC guild character is in (0=no NPC guild)
+	UI16		npcGuild;				// ID of NPC guild character is in (0=no NPC guild)
 
 	SKILLVAL	baseskill[ALLSKILLS]; 	// Base skills without stat modifiers
 	SKILLVAL	skill[INTELLECT+1]; 	// List of skills (with stat modifiers)

--- a/source/cChar.h
+++ b/source/cChar.h
@@ -164,13 +164,13 @@ private:
 
 		std::string	lastOn; //Last time a character was on
 		UI32		lastOnSecs; //Last time a character was on in seconds.
-		UI32		playTime; // Character's full playtime
 
 		SERIAL		townVote;
 		SI08		townPriv;  //0=non resident (Other privledges added as more functionality added)
 		UI08		controlSlotsUsed; // The total number of control slots currently taken up by followers/pets
 		UI32		createdOn;	// Timestamp for when player character was created
 		UI32		npcGuildJoined;	// Timestamp for when player character joined NPC guild (0=never joined)
+		UI32		playTime;	// Character's full playtime
 
 		UI08		atrophy[INTELLECT+1];
 		SkillLock	lockState[INTELLECT+1];	// state of the skill locks
@@ -217,7 +217,6 @@ protected:
   	UI16    	advObj;			// Has used advance gate?
   	SERIAL  	guildFealty;	// Serial of player you are loyal to (default=yourself) (DasRaetsel)
   	SI16    	guildNumber;	// Number of guild player is in (0=no guild)     (DasRaetsel)
-	UI16		npcGuild;		// ID of NPC guild character is in (0=no NPC guild)
 
   	UI08    	flag;			// 1=red 2=grey 4=Blue 8=green 10=Orange // should it not be 0x10??? sounds like we're trying to do
   	SI08    	spellCast;
@@ -239,6 +238,7 @@ protected:
 	UI08		PoisonStrength;
 	BodyType	bodyType;
 	UI32		lastMoveTime; 			// Timestamp for when character moved last
+	UI16		npcGuild;						// ID of NPC guild character is in (0=no NPC guild)
 
 	SKILLVAL	baseskill[ALLSKILLS]; 	// Base skills without stat modifiers
 	SKILLVAL	skill[INTELLECT+1]; 	// List of skills (with stat modifiers)
@@ -379,7 +379,7 @@ public:
 	bool		GetCanAttack( void ) const;
 	bool		IsAtWar( void ) const;
 	bool		IsPassive( void ) const;
-	auto		HasStolen() -> const bool;
+	auto		HasStolen() -> bool;
 	auto		HasStolen( bool newValue ) -> void;
 	bool		IsOnHorse( void ) const;
 	bool		GetTownTitle( void ) const;
@@ -818,7 +818,7 @@ public:
 	void		SetLastOnSecs( UI32 newValue );
 	UI32		GetLastOnSecs( void ) const;
 
-	auto		GetPlayTime() const -> const UI32;
+	auto		GetPlayTime() const -> UI32;
 	auto		SetPlayTime( UI32 newValue ) -> void;
 
 	void		SetCreatedOn( UI32 newValue );

--- a/source/cChar.h
+++ b/source/cChar.h
@@ -237,8 +237,8 @@ protected:
 
 	UI08		PoisonStrength;
 	BodyType	bodyType;
-	UI32		lastMoveTime; 			// Timestamp for when character moved last
-	UI16		npcGuild;				// ID of NPC guild character is in (0=no NPC guild)
+	UI32		lastMoveTime;		// Timestamp for when character moved last
+	UI16		npcGuild;		// ID of NPC guild character is in (0=no NPC guild)
 
 	SKILLVAL	baseskill[ALLSKILLS]; 	// Base skills without stat modifiers
 	SKILLVAL	skill[INTELLECT+1]; 	// List of skills (with stat modifiers)

--- a/source/cConsole.cpp
+++ b/source/cConsole.cpp
@@ -1004,7 +1004,7 @@ auto CConsole::Process(std::int32_t c) -> void
 				return;
 			}
 		}
-		CSocket *tSock	= nullptr;
+		[[maybe_unused]] CSocket *tSock	= nullptr;
 		//char outputline[128], temp[1024];
 		std::string outputline, temp;
 		SI32 indexcount	= 0;

--- a/source/cItem.cpp
+++ b/source/cItem.cpp
@@ -2683,8 +2683,8 @@ void CItem::SendToSocket( CSocket *mSock, [[maybe_unused]] bool drawGamePlayer )
 			auto iVisible = GetVisible();
 			auto ownerObj = GetOwnerObj();
 			if(( iVisible != VT_VISIBLE && iVisible != VT_TEMPHIDDEN )
-				|| iVisible == VT_TEMPHIDDEN &&
-				( !ValidateObject( ownerObj ) || ( ValidateObject( ownerObj ) && ownerObj->GetSerial() != mChar->GetSerial() )))
+				|| ((iVisible == VT_TEMPHIDDEN &&
+				( !ValidateObject( ownerObj ))) || ( ValidateObject( ownerObj ) && ownerObj->GetSerial() != mChar->GetSerial() )))
 			{
 				return;
 			}

--- a/source/cItem.cpp
+++ b/source/cItem.cpp
@@ -2682,9 +2682,9 @@ void CItem::SendToSocket( CSocket *mSock, [[maybe_unused]] bool drawGamePlayer )
 			// Not the owner, nor a GM
 			auto iVisible = GetVisible();
 			auto ownerObj = GetOwnerObj();
-			if(( iVisible != VT_VISIBLE && iVisible != VT_TEMPHIDDEN )
-				|| ((iVisible == VT_TEMPHIDDEN &&
-				( !ValidateObject( ownerObj ))) || ( ValidateObject( ownerObj ) && ownerObj->GetSerial() != mChar->GetSerial() )))
+			if((( iVisible != VT_VISIBLE && iVisible != VT_TEMPHIDDEN )
+				|| iVisible == VT_TEMPHIDDEN ) &&
+				( !ValidateObject( ownerObj ) || ( ValidateObject( ownerObj ) && ownerObj->GetSerial() != mChar->GetSerial() )))
 			{
 				return;
 			}

--- a/source/cItem.cpp
+++ b/source/cItem.cpp
@@ -2682,9 +2682,9 @@ void CItem::SendToSocket( CSocket *mSock, [[maybe_unused]] bool drawGamePlayer )
 			// Not the owner, nor a GM
 			auto iVisible = GetVisible();
 			auto ownerObj = GetOwnerObj();
-			if((( iVisible != VT_VISIBLE && iVisible != VT_TEMPHIDDEN )
-				|| iVisible == VT_TEMPHIDDEN ) &&
-				( !ValidateObject( ownerObj ) || ( ValidateObject( ownerObj ) && ownerObj->GetSerial() != mChar->GetSerial() )))
+			if(( iVisible != VT_VISIBLE && iVisible != VT_TEMPHIDDEN )
+				|| ( iVisible == VT_TEMPHIDDEN &&
+				( !ValidateObject( ownerObj ) || ( ValidateObject( ownerObj ) && ownerObj->GetSerial() != mChar->GetSerial() ))))
 			{
 				return;
 			}

--- a/source/cItem.h
+++ b/source/cItem.h
@@ -56,7 +56,7 @@ protected:
 	UI16			maxUses;		// Max number of uses an item can have
 	UI16			usesLeft;		// Current number of uses left on an item
 	UI16			regionNum;
-	TIMERVAL	tempLastTraded;			// Temporary timestamp for when item was last traded between players via secure trade window (not saved)
+	TIMERVAL		tempLastTraded;		// Temporary timestamp for when item was last traded between players via secure trade window (not saved)
 	UI08			stealable;		// 0=Not stealable, 1=Stealable (default, most items), 2=Special Stealable (town rares, etc)
 
 	std::bitset<8>	bools;

--- a/source/cItem.h
+++ b/source/cItem.h
@@ -48,16 +48,16 @@ protected:
 	UI16			entryMadeFrom;
 	SERIAL			creator;		// Store the serial of the player made this item
 	SI08			gridLoc;
-	SI32			weightMax;			// Maximum weight a container can hold
-	SI32			baseWeight;			// Base weight of item. Applied when item is created for the first time, based on weight. Primarily used to determine base weight of containers
-	UI16			maxItems;				// Maximum amount of items a container can hold
-	UI08			maxRange;				// Max range of ranged weapon
-	UI08			baseRange;			// Base range of thrown weapon
-	UI16			maxUses;				// Max number of uses an item can have
-	UI16			usesLeft;				// Current number of uses left on an item
+	SI32			weightMax;		// Maximum weight a container can hold
+	SI32			baseWeight;		// Base weight of item. Applied when item is created for the first time, based on weight. Primarily used to determine base weight of containers
+	UI16			maxItems;		// Maximum amount of items a container can hold
+	UI08			maxRange;		// Max range of ranged weapon
+	UI08			baseRange;		// Base range of thrown weapon
+	UI16			maxUses;		// Max number of uses an item can have
+	UI16			usesLeft;		// Current number of uses left on an item
 	UI16			regionNum;
-	TIMERVAL	tempLastTraded;	// Temporary timestamp for when item was last traded between players via secure trade window (not saved)
-	UI08			stealable;			// 0=Not stealable, 1=Stealable (default, most items), 2=Special Stealable (town rares, etc)
+	TIMERVAL	tempLastTraded;		// Temporary timestamp for when item was last traded between players via secure trade window (not saved)
+	UI08			stealable;		// 0=Not stealable, 1=Stealable (default, most items), 2=Special Stealable (town rares, etc)
 
 	std::bitset<8>	bools;
 	std::bitset<8>	priv; 			// Bit 0, decay off/on.  Bit 1, newbie item off/on.  Bit 2 Dispellable

--- a/source/cItem.h
+++ b/source/cItem.h
@@ -37,8 +37,6 @@ protected:
 	ARMORCLASS		armorClass;
 	UI16			restock;		// Number up to which shopkeeper should restock this item
 	SI08			movable;		// 0=Default as stored in client, 1=Always movable, 2=Never movable, 3=Owner movable.
-	UI08			stealable;		// 0=Not stealable, 1=Stealable (default, most items), 2=Special Stealable (town rares, etc)
-	TIMERVAL		tempLastTraded;	// Temporary timestamp for when item was last traded between players via secure trade window (not saved)
 	TIMERVAL		tempTimer;
 	TIMERVAL		decayTime;
 	UI08			spd;			// The speed of the weapon
@@ -50,6 +48,16 @@ protected:
 	UI16			entryMadeFrom;
 	SERIAL			creator;		// Store the serial of the player made this item
 	SI08			gridLoc;
+	SI32			weightMax;			// Maximum weight a container can hold
+	SI32			baseWeight;			// Base weight of item. Applied when item is created for the first time, based on weight. Primarily used to determine base weight of containers
+	UI16			maxItems;				// Maximum amount of items a container can hold
+	UI08			maxRange;				// Max range of ranged weapon
+	UI08			baseRange;			// Base range of thrown weapon
+	UI16			maxUses;				// Max number of uses an item can have
+	UI16			usesLeft;				// Current number of uses left on an item
+	UI16			regionNum;
+	TIMERVAL	tempLastTraded;	// Temporary timestamp for when item was last traded between players via secure trade window (not saved)
+	UI08			stealable;			// 0=Not stealable, 1=Stealable (default, most items), 2=Special Stealable (town rares, etc)
 
 	std::bitset<8>	bools;
 	std::bitset<8>	priv; 			// Bit 0, decay off/on.  Bit 1, newbie item off/on.  Bit 2 Dispellable
@@ -59,20 +67,11 @@ protected:
 	std::string		eventName;		// Name of custom event item belongs to
 
 	UI32			tempVars[CITV_COUNT];
-	SI32			weightMax;		// Maximum weight a container can hold
-	SI32			baseWeight;		// Base weight of item. Applied when item is created for the first time, based on weight. Primarily used to determine base weight of containers
-	UI16			maxItems;		// Maximum amount of items a container can hold
-	UI08			maxRange;		// Max range of ranged weapon
-	UI08			baseRange;		// Base range of thrown weapon
-	UI16			maxUses;		// Max number of uses an item can have
-	UI16			usesLeft;		// Current number of uses left on an item
 	UI08			dir;			// direction an item can have
 
 	UI32			value[3];		// Price a shopkeep buys and sells items for, with price on player vendor as optional third value
 	UI16			ammo[2];		// Ammo ID and Hue
 	UI16			ammoFX[3];		// Ammo-effect ID, Hue and rendermode
-
-	UI16			regionNum;
 
 	std::bitset<WEATHNUM>	weatherBools;	// For elemental weaponry.  So a Heat weapon would be a fire weapon, and does elemental damage to Heat weak races
 

--- a/source/cItem.h
+++ b/source/cItem.h
@@ -56,7 +56,7 @@ protected:
 	UI16			maxUses;		// Max number of uses an item can have
 	UI16			usesLeft;		// Current number of uses left on an item
 	UI16			regionNum;
-	TIMERVAL	tempLastTraded;		// Temporary timestamp for when item was last traded between players via secure trade window (not saved)
+	TIMERVAL	tempLastTraded;			// Temporary timestamp for when item was last traded between players via secure trade window (not saved)
 	UI08			stealable;		// 0=Not stealable, 1=Stealable (default, most items), 2=Special Stealable (town rares, etc)
 
 	std::bitset<8>	bools;

--- a/source/cScript.cpp
+++ b/source/cScript.cpp
@@ -211,7 +211,7 @@ std::string g_errorMessage;
 //| Notes		-	Relies on global variable g_errorMessage to pass in error message from
 //|					MethodError function.
 //o------------------------------------------------------------------------------------------------o
-const JSErrorFormatString* ScriptErrorCallback( void *userRef, const char *locale, const uintN errorNumber )
+const JSErrorFormatString* ScriptErrorCallback( [[maybe_unused]] void *userRef, [[maybe_unused]] const char *locale, [[maybe_unused]] const uintN errorNumber )
 {
 	// Return a pointer to a JSErrorFormatString, to the UOX3ErrorReporter function in cScript.cpp
 	static JSErrorFormatString errorFormat;

--- a/source/movement.cpp
+++ b/source/movement.cpp
@@ -3478,7 +3478,7 @@ auto CMovement::IgnoreAndEvadeTarget( CChar *mChar ) -> void
 			SI16 moveDist = RandomNum( 2, 5 );
 
 			double magnitude = sqrt( distanceX * distanceX + distanceY * distanceY );
-			int moveDir = Direction( mCharX, mCharY, mTargX, mTargY );
+			[[maybe_unused]] int moveDir = Direction( mCharX, mCharY, mTargX, mTargY );
 
 			SI16 evadeTargX = mCharX;
 			SI16 evadeTargY = mCharY;

--- a/source/npcs.cpp
+++ b/source/npcs.cpp
@@ -180,12 +180,12 @@ auto CCharStuff::ChooseNpcToCreate( const std::vector<std::pair<std::string, UI1
 	}
 
 	int rndChoice = RandomNum( 0, sum_of_weight - 1 );
-	int npcWeight = 0;
+	[[maybe_unused]] int npcWeight = 0;
 
 	std::vector<int> matchingEntries;
 
 	int weightOfChosenNpc = 0;
-	for( int i = 0; i < npcListVector.size(); ++i )
+	for( size_t i = 0; i < npcListVector.size(); ++i )
 	{
 		//const std::string &sectionName = npcList[i].first;
 		const UI16 &sectionWeight = npcListVector[i].second;

--- a/source/skills.cpp
+++ b/source/skills.cpp
@@ -2495,7 +2495,7 @@ void CallGuards( CChar *mChar, CChar *targChar );
 void CSkills::Snooping( CSocket *s, CChar *target, CItem *pack )
 {
 	CChar *mChar = s->CurrcharObj();
-	CSocket *tSock = target->GetSocket();
+	[[maybe_unused]] CSocket *tSock = target->GetSocket();
 
 	std::vector<UI16> scriptTriggers = mChar->GetScriptTriggers();
 	for( auto scriptTrig : scriptTriggers )

--- a/source/uox3.cpp
+++ b/source/uox3.cpp
@@ -231,7 +231,7 @@ auto main( SI32 argc, char *argv[] ) ->int
 
 	// Start/Initalize classes, data, network
 	StartInitialize( serverdata );
-	
+
 	// Main Loop
 	Console.PrintSectionBegin();
 	EVENT_TIMER( stopwatch, EVENT_TIMER_OFF );
@@ -241,7 +241,7 @@ auto main( SI32 argc, char *argv[] ) ->int
 	// necessary to keep shard performance and responsiveness to player input at acceptable levels
 	auto apsPerfThreshold = cwmWorldState->ServerData()->APSPerfThreshold(); // Performance threshold from ini, 0 disables APS feature
 
-	int avgSimCycles = 0;
+	[[maybe_unused]] int avgSimCycles = 0;
 	UI16 apsMovingAvgOld = 0;
 	const int maxSimCycleSamples = 10;  // Max number of samples for moving average
 	std::vector<int> simCycleSamples;  // Store simulation cycle measurements for moving average
@@ -255,7 +255,7 @@ auto main( SI32 argc, char *argv[] ) ->int
 	// Setup initial values for apsDelay
 	std::chrono::milliseconds apsDelay = std::chrono::milliseconds( 0 );
 	std::chrono::time_point<std::chrono::system_clock> adaptivePerfTimer = std::chrono::system_clock::now() + apsDelay;
-	
+
 	// Set the interval for APS evaluation and adjustment, and set initial timestamp for first evaluation
 	const std::chrono::milliseconds evaluationInterval = std::chrono::milliseconds( cwmWorldState->ServerData()->APSInterval() );
 	std::chrono::time_point<std::chrono::system_clock> nextEvaluationTime = std::chrono::system_clock::now() + evaluationInterval;


### PR DESCRIPTION
* Fixed initialization order
* Marked unused variables
* Fixed loop iterator data type
* Removed useless `const` qualifiers
* Removed extraneous whitespace
* Used additional parentheses in comparisons to make intent clearer