### PR TITLE
Fixes to Blacksmithing BOD Reward Items.

### DIFF
--- a/data/js/item/equip_effects/skill_boosting_equipment.js
+++ b/data/js/item/equip_effects/skill_boosting_equipment.js
@@ -21,10 +21,10 @@ function onEquip( pEquipper, iEquipped )
 	switch( skillBonusID )
 	{
 		case 7: // Blacksmithing
-			pEquipper.baseskills.blacksmithing += skillBonusVal;
+			pEquipper.skills.blacksmithing += skillBonusVal;
 			break;
 		case 45: // Mining
-			pEquipper.baseskills.mining += skillBonusVal;
+			pEquipper.skills.mining += skillBonusVal;
 			break;
 		default:
 			break;
@@ -39,10 +39,10 @@ function onUnequip( pUnquipper, iUnequipped )
 	switch( skillBonusID )
 	{
 		case 7: // Blacksmithing
-			pUnquipper.baseskills.blacksmithing -= skillBonusVal;
+			pUnquipper.skills.blacksmithing -= skillBonusVal;
 			break;
 		case 45: // Mining
-			pUnquipper.baseskills.mining -= skillBonusVal;
+			pUnquipper.skills.mining -= skillBonusVal;
 			break;
 		default:
 			break;

--- a/data/js/npc/ai/vendor_bdo_dispenser.js
+++ b/data/js/npc/ai/vendor_bdo_dispenser.js
@@ -694,17 +694,17 @@ function DispenseBODRewards( pDropper, npcDroppedOn, iDropped )
 		minReward = 0 + minMaxMod[0];
 		maxReward = 16 + minMaxMod[1];
 
-		switch( WeightedRandom( minReward, maxReward, weightVal ))
+		switch( WeightedRandom( minReward, maxReward, weightVal ) )
 		{
 			case 0: // Sturdy Pickaxe / Sturdy Shovel (equal chance)
-				switch( RandomNumber( 0, 1 ))
+				switch( RandomNumber( 0, 1 ) )
 				{
 					case 0: // Sturdy Pickaxe
 						bodRewardItem = CreateBODReward( 0, socket, pDropper, 0 );
 						break;
 					case 1: // Sturdy Shovel
-						break;
 						bodRewardItem = CreateBODReward( 1, socket, pDropper, 0 );
+						break;
 					default:
 						break;
 				}


### PR DESCRIPTION
Makes the following changes:
- Fixes an issue that causes BOD reward dispensing to error out whenever a Sturdy Shovel is rolled.
- Changes skill boosting items (i.e. mining gloves and smithy hammer) to modify effective skills instead of base skills.