### PR TITLE
instant logout

### DIFF
--- a/source/Changelog.txt
+++ b/source/Changelog.txt
@@ -1,3 +1,6 @@
+19/11/2023 - Dragon Slayer
+	Fixed an issue where players qualifying for instant logout would not immediately vanish from view upon logout (Xuri)
+
 18/11/2023 - Xuri
 	Enhance the calculation of the average 'z' for movement.
 

--- a/source/network.cpp
+++ b/source/network.cpp
@@ -455,7 +455,7 @@ void CNetworkStuff::LogOut( CSocket *s )
 		{
 			actbAccount.dwInGame = INVALIDSERIAL;
 		}
-		p->SetTimer( tPC_LOGOUT, 0 );
+		p->SetTimer( tPC_LOGOUT, 1 );
 		s->ClearTimers();
 	}
 	else

--- a/source/uox3.cpp
+++ b/source/uox3.cpp
@@ -2638,6 +2638,7 @@ auto CWorldMain::CheckAutoTimers() -> void
 						if( oaiw == INVALIDSERIAL )
 						{
 							charCheck->SetTimer( tPC_LOGOUT, 0 );
+							charCheck->RemoveFromSight();
 							charCheck->Update();
 						}
 						else if(( oaiw == charCheck->GetSerial() ) && (( charCheck->GetTimer( tPC_LOGOUT ) <= GetUICurrentTime() ) || GetOverflow() ))


### PR DESCRIPTION
Fixed an issue where players qualifying for instant logout would not immediately vanish from view upon logout (Xuri)