### PR TITLE
accounts

### DIFF
--- a/source/CPacketReceive.cpp
+++ b/source/CPacketReceive.cpp
@@ -397,7 +397,7 @@ void CPIFirstLogin::Receive( void )
 	char temp[30];
 	// Grab our username
 	memcpy( temp, &tSock->Buffer()[1], 30 );
-	userId = temp;
+	userId = oldstrutil::trim( temp );
 
 	// Grab our password
 	memcpy( temp, &tSock->Buffer()[31], 30 );
@@ -547,7 +547,7 @@ void CPISecondLogin::Receive( void )
 
 	// Grab our username
 	memcpy( temp, &tSock->Buffer()[5], 30 );
-	sid = temp;
+	sid = oldstrutil::trim( temp );
 
 	// Grab our password
 	memcpy( temp, &tSock->Buffer()[35], 30 );

--- a/source/Changelog.txt
+++ b/source/Changelog.txt
@@ -1,3 +1,6 @@
+22/03/2024 - Dragon Slayer/Xuri
+	Leading/trailing whitespace is now trimmed from account names during login.
+
 21/03/2024 - Dragon Slayer/Xuri
 	Fixed an issue with onHunger and onThirst event crashing if the npc was not loaded yet.
 


### PR DESCRIPTION
Leading/trailing whitespace is now trimmed from account names during login.