### PR TITLE
Small Fixes

### DIFF
--- a/data/js/item/runebook.js
+++ b/data/js/item/runebook.js
@@ -24,7 +24,11 @@ function onUseChecked( pUser, runeBook )
 	// get users socket
 	var pSocket = pUser.socket;
 
-	if( runeBook.GetTag( "useDelayed" ))
+	var iTime = GetCurrentClock();
+	var NextUse = runeBook.GetTag( "useDelayed" );
+	var Delay = 7000;
+
+	if( ( iTime - NextUse ) < Delay )
 	{
 		pSocket.SysMessage( GetDictionaryEntry( 9250, pSocket.language )); // This book needs time to recharge.
 		return false;
@@ -500,8 +504,8 @@ function onGumpPress( pSocket, myButton, gumpData )
 				pSocket.tempInt2 = ( myButton - 30 );
 				runeBook.SetTag( "inUse", null );
 				runeBook.SetTag( "userSerial", null );
-				runeBook.SetTag( "useDelayed", true );
-				runeBook.StartTimer( useDelay, 100, true );
+				var iTime = GetCurrentClock();
+				runeBook.SetTag( "useDelayed", iTime.toString() );
 				CastSpell( pSocket, pUser, 32, false );
 			}
 			else
@@ -598,8 +602,8 @@ function onGumpPress( pSocket, myButton, gumpData )
 				pSocket.tempInt2 = ( myButton - 120 );
 				runeBook.SetTag( "inUse", null );
 				runeBook.SetTag( "userSerial", null );
-				runeBook.SetTag( "useDelayed", true );
-				runeBook.StartTimer( useDelay, 100, true );
+				var iTime = GetCurrentClock();
+				runeBook.SetTag( "useDelayed", iTime.toString() );
 				CastSpell( pSocket, pUser, 32, true );
 			}
 			else
@@ -630,8 +634,8 @@ function onGumpPress( pSocket, myButton, gumpData )
 				pSocket.tempInt2 = ( myButton - 140 );
 				runeBook.SetTag( "inUse", null );
 				runeBook.SetTag( "userSerial", null );
-				runeBook.SetTag( "useDelayed", true );
-				runeBook.StartTimer( useDelay, 100, true );
+				var iTime = GetCurrentClock();
+				runeBook.SetTag( "useDelayed", iTime.toString() );
 				CastSpell( pSocket, pUser, 52, true );
 			}
 			else
@@ -813,13 +817,6 @@ function CastSpell( pSocket, pUser, spellNum, checkReagentReq )
 
 function onTimer( timerObj, timerID )
 {
-	if( timerID == 100 )
-	{
-		if( ValidateObject( timerObj ) && timerObj.isItem )
-		{
-			timerObj.SetTag( "useDelayed", null );
-		}
-	}
 	var pSocket = timerObj.socket;
 	if( !pSocket )
 		return;

--- a/data/js/jse_fileassociations.scp
+++ b/data/js/jse_fileassociations.scp
@@ -320,7 +320,7 @@
 6000=magic/helper/check_resist.js
 6001=magic/helper/calc_final_spell_damage.js
 6002=magic/helper/check_travel_restrictions.js
-6003=magic/helper/check_teleport.js
+6003=magic/helper/teleport_helper.js
 6004=magic/helper/check_reagents.js
 
 //-------------------------------------------

--- a/source/Changelog.txt
+++ b/source/Changelog.txt
@@ -1,3 +1,9 @@
+4/06/2024 - Dragon Slayer
+	Fixed Runebook Cooldown:
+		The Runebook now uses GetCurrentClock() instead of a timer, ensuring accurate 	checks for a 7-second delay using the system clock of the server.
+	Teleport Helper Name Correction:
+		The incorrect name in jse_fileassociations for the Teleport Helper has been fixed.
+
 22/03/2024 - Dragon Slayer/Xuri
 	Leading/trailing whitespace is now trimmed from account names during login.
 


### PR DESCRIPTION
Fixed Runebook Cooldown:
The Runebook now uses GetCurrentClock() instead of a timer, ensuring accurate checks for a 7-second delay using the system clock of the server. Teleport Helper Name Correction:
The incorrect name in jse_fileassociations for the Teleport Helper has been fixed.