### PR TITLE
Time Issue Resolved

### DIFF
--- a/source/Changelog.txt
+++ b/source/Changelog.txt
@@ -1,3 +1,7 @@
+15/03/2025 - Dragon Slayer
+	Fixed an issue where timestamps for system timers could be set in the past due to float-to-UI32 casting precision loss. ( Thanks Xuri )
+
+
 09/03/2025 - Dragon Slayer
 	Added new DFN tags for Magic:
 	BATWING, DAEMONBLOOD, GRAVEDUST, NOXCRYSTAL, PIGIRON

--- a/source/Changelog.txt
+++ b/source/Changelog.txt
@@ -1,7 +1,6 @@
 15/03/2025 - Dragon Slayer
 	Fixed an issue where timestamps for system timers could be set in the past due to float-to-UI32 casting precision loss. ( Thanks Xuri )
 
-
 09/03/2025 - Dragon Slayer
 	Added new DFN tags for Magic:
 	BATWING, DAEMONBLOOD, GRAVEDUST, NOXCRYSTAL, PIGIRON

--- a/source/funcdecl.h
+++ b/source/funcdecl.h
@@ -142,7 +142,7 @@ void	CallGuards( CChar *mChar );
 //o------------------------------------------------------------------------------------------------o
 inline TIMERVAL BuildTimeValue( R32 timeFromNow )
 {
-	return static_cast<TIMERVAL>( cwmWorldState->GetUICurrentTime() + ( static_cast<R32>( 1000 ) * timeFromNow ));
+	return static_cast<TIMERVAL>( cwmWorldState->GetUICurrentTime() + static_cast<TIMERVAL>( std::round(( static_cast<R32>( 1000 ) * timeFromNow ))));
 }
 
 UI32	GetClock( void );


### PR DESCRIPTION
Fixed an issue where timestamps for system timers could be set in the past due to float-to-UI32 casting precision loss.