### PR TITLE
Dropping Gold Fix

### DIFF
--- a/data/js/npc/ai/guildmaster.js
+++ b/data/js/npc/ai/guildmaster.js
@@ -152,6 +152,7 @@ function onSpeech( strSaid, pChar, npcGuildMaster )
 						dictMsg = dictMsg.replace( /%d/gi, GetDictionaryEntry( npcGuilds[npcGuildMaster.npcGuild][0], pSock.language )); // %d [npc guild name]
 						dictMsg = GetDictionaryEntry( 17602, pSock.language ); // There is a fee in gold coins for joining the guild : %i
 						npcGuildMaster.TextMessage( dictMsg.replace( /%i/gi, joinGuildCost ));
+						pChar.SetTempTag( "guildServiceRequest", true );
 					}
 					trigWordHandled = true;
 					break;
@@ -218,7 +219,7 @@ function onDropItemOnNpc( pChar, npcGuildMaster, iDropped )
 	if( pSock == null )
 		return 0;
 
-	if( iDropped.id == 0x0eed ) // Gold
+	if( iDropped.id == 0x0eed && pChar.GetTempTag( "guildServiceRequest" ) == true ) // Gold
 	{
 		if( pChar.npcGuild == npcGuildMaster.npcGuild )
 		{

--- a/data/js/npc/ai/guildmaster.js
+++ b/data/js/npc/ai/guildmaster.js
@@ -152,7 +152,7 @@ function onSpeech( strSaid, pChar, npcGuildMaster )
 						dictMsg = dictMsg.replace( /%d/gi, GetDictionaryEntry( npcGuilds[npcGuildMaster.npcGuild][0], pSock.language )); // %d [npc guild name]
 						dictMsg = GetDictionaryEntry( 17602, pSock.language ); // There is a fee in gold coins for joining the guild : %i
 						npcGuildMaster.TextMessage( dictMsg.replace( /%i/gi, joinGuildCost ));
-						pChar.SetTempTag( "guildServiceRequest", true );
+						pChar.SetTempTag( "guildServiceRequest", "joinGuild" );
 					}
 					trigWordHandled = true;
 					break;
@@ -219,7 +219,7 @@ function onDropItemOnNpc( pChar, npcGuildMaster, iDropped )
 	if( pSock == null )
 		return 0;
 
-	if( iDropped.id == 0x0eed && pChar.GetTempTag( "guildServiceRequest" ) == true ) // Gold
+	if( iDropped.id == 0x0eed && pChar.GetTempTag( "guildServiceRequest" ) != 0 ) // Gold
 	{
 		if( pChar.npcGuild == npcGuildMaster.npcGuild )
 		{
@@ -236,7 +236,7 @@ function onDropItemOnNpc( pChar, npcGuildMaster, iDropped )
 		{
 			npcGuildMaster.TextMessage( GetDictionaryEntry( 17609, pSock.language )); // Thou must resign from thy other guild first.
 		}
-		else if( CheckJoinGuildRequirements( pSock, pChar, npcGuildMaster ))
+		else if( pChar.GetTempTag( "guildServiceRequest" ) == "joinGuild" && CheckJoinGuildRequirements( pSock, pChar, npcGuildMaster ))
 		{
 			if( iDropped.amount >= joinGuildCost )
 			{
@@ -247,6 +247,7 @@ function onDropItemOnNpc( pChar, npcGuildMaster, iDropped )
 
 				// Get the current timestamp in milliseconds, but round to minutes before storing in character property
 				pChar.npcGuildJoined = Math.floor( Date.now() / ( 60 * 1000 ));
+				pChar.SetTempTag( "guildServiceRequest", null );
 
 				// Subtract the joining fee!
 				if( iDropped.amount > joinGuildCost )

--- a/data/js/npc/ai/vendor_bdo_dispenser.js
+++ b/data/js/npc/ai/vendor_bdo_dispenser.js
@@ -668,9 +668,10 @@ function onDropItemOnNpc( pDropper, npcDroppedOn, iDropped )
 	if( socket == null )
 		return false;
 
+	// Return true allows code/other scripts to handle "gold drop" on this NPC
 	if( iDropped.id == 0x0eed )
 	{
-		return 1;
+		return true;
 	}
 
 	var amountMax 	  = iDropped.GetTag( "amountMax" ); 	 // amount you have to make of the item

--- a/data/js/npc/ai/vendor_bdo_dispenser.js
+++ b/data/js/npc/ai/vendor_bdo_dispenser.js
@@ -668,6 +668,11 @@ function onDropItemOnNpc( pDropper, npcDroppedOn, iDropped )
 	if( socket == null )
 		return false;
 
+	if( iDropped.id == 0x0eed )
+	{
+		return 1;
+	}
+
 	var amountMax 	  = iDropped.GetTag( "amountMax" ); 	 // amount you have to make of the item
 	var amountCur 	  = iDropped.GetTag( "amountCur" ); 	 // amount you have combined
 	var iBodType 	  = iDropped.GetTag( "bodType" ); 	     // BOD type of the BOD itself

--- a/source/Changelog.txt
+++ b/source/Changelog.txt
@@ -1,3 +1,6 @@
+30/04/2025 - Dragon Slayer
+	Fixed: Dropping gold on NPCs flagged as guildmasters or BOD handlers will now correctly allow skill training unless the player is explicitly attempting to join a guild or turn in a BOD.
+
 29/04/2025 - Xuri
 	Revamped 'wholist GM command entirely in JS, now comes with filters for names, online/offline status, sorting by name or last online date, quick-buttons to tweak/teleport/inspect, etc. Updated syntax:
 		'wholist [on]


### PR DESCRIPTION
Fixed: Dropping gold on NPCs flagged as guildmasters or BOD handlers will now correctly allow skill training unless the player is explicitly attempting to join a guild or turn in a BOD.