### PR TITLE
Healing Overhaul, fixes for mana regen, skill caps

### DIFF
--- a/data/dictionaries/dictionary.CSY
+++ b/data/dictionaries/dictionary.CSY
@@ -3739,6 +3739,15 @@
 8213=ID sekce z DFNs objekt pochází z
 8214=Dá se předmět ukrást? 0 = nelze ukrást, 1 = lze ukrást, 2 = lze ukrást vzácně
 8215=Neplatný cíl. Vyberte platnou položku nebo NPC
+8251=Vymazání NPC...
+8252=Vymazáno %i NPC
+8253=Vyberte NPC, které chcete přesunout na dálku pomocí xrun:
+8254=Vyberte NPC, které chcete přesunout na dálku pomocí xwalk:
+8255=Vyberte NPC, které chcete otočit na dálku pomocí xturn:
+8256=Vyberte cíl pohybu (%s):
+8257=Musíte vybrat NPC!
+8258=Ošetřil jsi ránu a zastavil krvácení
+8259=Krvácející rány se zahojily, už nekrvácíš!
 // [8300-8499] Tweak menu - Character property descriptions
 8300=Číslo účtu přidružené k hráči. Řízeno serverem (pouze pro čtení)
 8301=Typ umělé inteligence NPC

--- a/data/dictionaries/dictionary.ENG
+++ b/data/dictionaries/dictionary.ENG
@@ -3741,6 +3741,15 @@
 8213=Section ID from DFNs object originated from
 8214=Is item stealable? 0 = not stealable, 1 = stealable, 2 = stealable rare
 8215=Invalid target. Please select a valid item or NPC
+8251=Wiping NPCs...
+8252=Wiped %i NPCs
+8253=Select NPC to move remotely using xrun:
+8254=Select NPC to move remotely using xwalk:
+8255=Select NPC to turn remotely using xturn:
+8256=Select movement (%s) destination:
+8257=You must target an NPC!
+8258=You bind the wound and stop the bleeding
+8259=The bleeding wounds have healed, you are no longer bleeding!
 // [8300-8499] Tweak menu - Character property descriptions
 8300=Account number associated with player. Controlled by server (Read-Only)
 8301=NPC AI Type

--- a/data/dictionaries/dictionary.FRE
+++ b/data/dictionaries/dictionary.FRE
@@ -3905,6 +3905,15 @@
 8213=Identification de la section dans les DFNs d'où provient l'objet.
 8214=L'objet est-il volable ? 0 = non volable, 1 = volable, 2 = volable rare
 8215=Cible invalide. Veuillez sélectionner un objet ou un PNJ valide
+8251=Suppression des PNJ...
+8252=Suppression de %i PNJ
+8253=Sélectionnez le PNJ à déplacer à distance à l'aide de xrun :
+8254=Sélectionnez le PNJ à déplacer à distance à l'aide de xwalk :
+8255=Sélectionnez le PNJ à faire pivoter à distance à l'aide de xturn :
+8256=Sélectionnez la destination du déplacement (%s) :
+8257=Vous devez cibler un PNJ !
+8258=Vous pansez la blessure et arrêtez l'hémorragie
+8259=Les blessures hémorragiques sont guéries, vous ne saignez plus !
 // [8300-8499] Tweak menu - Character property descriptions
 8300=Numéro de compte associé au joueur. Contrôlé par le serveur (en lecture seule).
 8301=Type d'IA du PNJ

--- a/data/dictionaries/dictionary.GER
+++ b/data/dictionaries/dictionary.GER
@@ -3741,6 +3741,15 @@
 8213=Schnittstellen-ID aus DFNs, aus denen das Objekt stammt
 8214=Ist der Gegenstand stehlbar? 0 = nicht stehlbar, 1 = stehlbar, 2 = selten stehlbar
 8215=Ungültiges Ziel. Bitte wählen Sie einen gültigen Gegenstand oder NPC aus
+8251=NPCs löschen...
+8252=%i NPCs gelöscht
+8253=Wähle einen NPC aus, der mit xrun ferngesteuert bewegt werden soll:
+8254=Wähle einen NPC aus, der mit xwalk ferngesteuert bewegt werden soll:
+8255=Wähle einen NPC aus, der mit xturn ferngesteuert gedreht werden soll:
+8256=Wähle das Bewegungsziel (%s) aus:
+8257=Du musst einen NPC als Ziel auswählen!
+8258=Du verbindest die Wunde und stillst die Blutung
+8259=Die blutenden Wunden sind verheilt, du blutest nicht mehr!
 // [8300-8499] Tweak menu - Character property descriptions
 8300=Kontonummer, die dem Spieler zugeordnet ist. Wird vom Server gesteuert (Read-Only)
 8301=NPC-KI-Typ

--- a/data/dictionaries/dictionary.ITA
+++ b/data/dictionaries/dictionary.ITA
@@ -3741,6 +3741,15 @@
 8213=Identità della sezione da cui proviene l'oggetto DFN
 8214=L'oggetto è rubabile? 0 = non rubabile, 1 = rubabile, 2 = rubabile raramente
 8215=Destinazione non valida. Seleziona un oggetto o NPC valido
+8251=Cancellazione NPC...
+8252=NPC cancellati: %i
+8253=Seleziona NPC da spostare a distanza usando xrun:
+8254=Seleziona NPC da spostare a distanza usando xwalk:
+8255=Seleziona NPC da girare a distanza usando xturn:
+8256=Seleziona destinazione movimento (%s):
+8257=Devi selezionare un NPC!
+8258=Hai bendato la ferita e fermato l'emorragia
+8259=Le ferite sanguinanti sono guarite, non stai più sanguinando!
 // [8300-8499] Tweak menu - Character property descriptions
 8300=Numero di account associato al giocatore. Controllato dal server (Solo lettura)
 8301=Tipo di IA del PNG

--- a/data/dictionaries/dictionary.POL
+++ b/data/dictionaries/dictionary.POL
@@ -3741,6 +3741,15 @@
 8213=Identyfikator sekcji z DFN, z którego pochodzi obiekt
 8214=Czy przedmiot można ukraść? 0 = nie można ukraść, 1 = można ukraść, 2 = można ukraść rzadko
 8215=Nieprawidłowy cel. Wybierz prawidłowy przedmiot lub NPC
+8251=Usuwanie postaci niezależnych...
+8252=Usunięto %i postaci niezależnych
+8253=Wybierz postać niezależną do zdalnego przeniesienia za pomocą xrun:
+8254=Wybierz postać niezależną do zdalnego przeniesienia za pomocą xwalk:
+8255=Wybierz postać niezależną do zdalnego obrócenia za pomocą xturn:
+8256=Wybierz cel ruchu (%s):
+8257=Musisz wybrać postać niezależną!
+8258=Opatrujesz ranę i zatrzymujesz krwawienie
+8259=Krwawiące rany zostały wyleczone, nie krwawisz już!
 // [8300-8499] Menu ustawień - opisy właściwości znaków
 8300=Numer konta powiązanego z graczem. Kontrolowany przez serwer (tylko do odczytu)
 8301=Typ SI NPC

--- a/data/dictionaries/dictionary.PTG
+++ b/data/dictionaries/dictionary.PTG
@@ -3741,6 +3741,15 @@
 8213=Secção ID do objecto do DFN originado de
 8214=O artigo pode ser roubado? 0 = não pode ser roubado, 1 = pode ser roubado, 2 = pode ser roubado raramente
 8215=Alvo inválido. Selecione um item ou NPC válido
+8251=A limpar NPCs...
+8252=Limpos %i NPCs
+8253=Selecione o NPC para mover remotamente usando xrun:
+8254=Selecione o NPC para mover remotamente usando xwalk:
+8255=Selecione o NPC para virar remotamente usando xturn:
+8256=Selecione o destino do movimento (%s):
+8257=Tem de selecionar um NPC!
+8258=Você faz um curativo e estanca o sangramento
+8259=As feridas sangrentas sararam, você não está mais sangrando!
 // [8300-8499] Tweak menu - Character property descriptions
 8300=Número de conta associado ao jogador. Controlado por servidor (Read-Only)
 8301=NPC Tipo de IA

--- a/data/dictionaries/dictionary.SPA
+++ b/data/dictionaries/dictionary.SPA
@@ -3741,6 +3741,15 @@
 8213=Identificación de la sección de DFNs de la que procede el objeto
 8214=¿Se puede robar el objeto? 0 = no robable, 1 = robable, 2 = robable raro
 8215=Alvo inválido. Selecione um item ou NPC válido
+8251=Borrar NPC...
+8252=Se han borrado %i NPC
+8253=Selecciona un NPC para moverlo a distancia con xrun:
+8254=Selecciona un NPC para moverlo a distancia con xwalk:
+8255=Selecciona un NPC para girarlo a distancia con xturn:
+8256=Selecciona el destino del movimiento (%s):
+8257=¡Debes seleccionar un NPC!
+8258=Vendas la herida y detienes la hemorragia.
+8259=Las heridas sangrantes se han curado, ¡ya no sangras!
 // [8300-8499] Menú de ajustes - Descripciones de las propiedades de los personajes
 8300=Número de cuenta asociado al jugador. Controlado por el servidor (sólo lectura)
 8301=Tipo de IA del PNJ

--- a/data/dictionaries/dictionary.ZRO
+++ b/data/dictionaries/dictionary.ZRO
@@ -3741,6 +3741,15 @@
 8213=Section ID from DFNs object originated from
 8214=Is item stealable? 0 = not stealable, 1 = stealable, 2 = stealable rare
 8215=Invalid target. Please select a valid item or NPC
+8251=Wiping NPCs...
+8252=Wiped %i NPCs
+8253=Select NPC to move remotely using xrun:
+8254=Select NPC to move remotely using xwalk:
+8255=Select NPC to turn remotely using xturn:
+8256=Select movement (%s) destination:
+8257=You must target an NPC!
+8258=You bind the wound and stop the bleeding
+8259=The bleeding wounds have healed, you are no longer bleeding!
 // [8300-8499] Tweak menu - Character property descriptions
 8300=Account number associated with player. Controlled by server (Read-Only)
 8301=NPC AI Type

--- a/data/js/commands/custom/misc-cmd.js
+++ b/data/js/commands/custom/misc-cmd.js
@@ -59,6 +59,7 @@ function CommandRegistration()
 	RegisterCommand( "gettemptagmap", 2, true ); // Spit out a list of all custom tags on object
 	RegisterCommand( "listpets", 2, true ); // Spit out a list of all pets owned by target
 	RegisterCommand( "listfollowers", 2, true ); // Spit out a list of all followers of target
+	RegisterCommand( "resetskillcaps", 3, true ); // Fix corrupted player skill caps
 }
 
 function command_RENAME( pSock, execString )
@@ -1051,7 +1052,7 @@ function onCallback29( pSock, myTarget )
 			pSock.SysMessage( tempMsg.replace( /%s/gi, newExpiryTime ));
 
 			tempMsg = GetDictionaryEntry( 2765, pSock.language ); // // Remaining time: %d seconds
-			pSock.SysMessage(tempMsg.replace(/%d/gi, Math.round(( expiryTime - currentTime ) / 1000 ).toString() ));
+			pSock.SysMessage( tempMsg.replace( /%d/gi, Math.round(( expiryTime - currentTime ) / 1000 ).toString() ));
 		}
 		else
 		{
@@ -1192,7 +1193,7 @@ function onCallback32( socket, ourObj )
 		var StrangeByte = socket.GetWord(1);
 
 		// If connected with a client lower than v7.0.9, manually add height of targeted tile
-		if ((StrangeByte == 0 && ourObj.isItem) || (socket.clientMajorVer <= 7 && socket.clientSubVer < 9))
+		if(( StrangeByte == 0 && ourObj.isItem ) || ( socket.clientMajorVer <= 7 && socket.clientSubVer < 9 ))
 		{
 			z += GetTileHeight( socket.GetWord( 17 ));
 		}
@@ -1243,7 +1244,7 @@ function onCallback33( socket, ourObj )
 		var StrangeByte = socket.GetWord(1);
 
 		// If connected with a client lower than v7.0.9, manually add height of targeted tile
-		if ((StrangeByte == 0 && ourObj.isItem) || (socket.clientMajorVer <= 7 && socket.clientSubVer < 9))
+		if(( StrangeByte == 0 && ourObj.isItem ) || ( socket.clientMajorVer <= 7 && socket.clientSubVer < 9 ))
 		{
 			z += GetTileHeight( socket.GetWord( 17 ));
 		}
@@ -1402,6 +1403,22 @@ function onCallback38( pSock, ourObj )
 			}
 		}
 	}
+}
+
+function command_RESETSKILLCAPS( pSock, execString )
+{
+	var resetCount = IterateOver( "CHARACTER" );
+	pSock.SysMessage( "Reset skillcaps for " + resetCount + " players back to default." );
+}
+
+function onIterate( toCheck )
+{
+	if( toCheck.isChar && !toCheck.npc )
+	{
+		toCheck.skillCaps.allskills = 0;
+		return true;
+	}
+	return false;
 }
 
 function _restorecontext_() {}

--- a/data/js/commands/custom/misc-cmd.js
+++ b/data/js/commands/custom/misc-cmd.js
@@ -60,6 +60,7 @@ function CommandRegistration()
 	RegisterCommand( "listpets", 2, true ); // Spit out a list of all pets owned by target
 	RegisterCommand( "listfollowers", 2, true ); // Spit out a list of all followers of target
 	RegisterCommand( "resetskillcaps", 3, true ); // Fix corrupted player skill caps
+	RegisterCommand( "resetskillusage", 3, true ); // Fix stuck skill usage for all players
 }
 
 function command_RENAME( pSock, execString )
@@ -1405,6 +1406,7 @@ function onCallback38( pSock, ourObj )
 	}
 }
 
+// Reset corrupted skill caps for player characters. Only use in emergency.
 function command_RESETSKILLCAPS( pSock, execString )
 {
 	var resetCount = IterateOver( "CHARACTER" );
@@ -1416,6 +1418,23 @@ function onIterate( toCheck )
 	if( toCheck.isChar && !toCheck.npc )
 	{
 		toCheck.skillCaps.allskills = 0;
+		return true;
+	}
+	return false;
+}
+
+// Reset stuck skill usage for player characters. Only use in emergency.
+function command_RESETSKILLUSAGE( pSock, execString )
+{
+	var resetCount = IterateOver( "CHARACTER" );
+	pSock.SysMessage( "Reset skill usage for " + resetCount + " players back to false." );
+}
+
+function onIterate( toCheck )
+{
+	if( toCheck.isChar && !toCheck.npc )
+	{
+		toCheck.skillsused.allskills = false;
 		return true;
 	}
 	return false;

--- a/data/js/commands/targeting/set.js
+++ b/data/js/commands/targeting/set.js
@@ -520,6 +520,20 @@ function HandleSetItem( socket, ourItem, uKey, splitString )
 		ourItem.layer = nVal;
 		okMsg( socket );
 		break;
+	case "DAMAGE":
+		var splitValues = socket.xText.split( " " );
+		if( splitValues[2] )
+		{
+			ourItem.lodamage = parseInt( splitValues[1] );
+			ourItem.hidamage = parseInt( splitValues[2] );
+		}
+		else
+		{
+			ourItem.lodamage = parseInt( splitValues[1] );
+			ourItem.hidamage = parseInt( splitValues[1] );
+		}
+		ourItem.Refresh();
+		okMsg( socket );
 	case "LODAMAGE":
 		ourItem.lodamage = nVal;
 		okMsg( socket );

--- a/data/js/commands/targeting/xwalk.js
+++ b/data/js/commands/targeting/xwalk.js
@@ -28,7 +28,7 @@ function command_XWALK( socket, cmdString )
 	{
 		socket.ignoreDoors = true;
 	}
-	pUser.CustomTarget( 0, GetDictionaryEntry( 8243, socket.language )); // Select NPC to move remotely using xwalk:
+	pUser.CustomTarget( 0, GetDictionaryEntry( 8254, socket.language )); // Select NPC to move remotely using xwalk:
 }
 
 function command_XRUN( socket, cmdString )
@@ -55,7 +55,7 @@ function command_XTURN( socket, cmdString )
 {
 	var pUser = socket.currentChar;
 	socket.xText = "turn";
-	pUser.CustomTarget( 0, GetDictionaryEntry( 8244, socket.language )); // Select NPC to turn remotely using xturn:
+	pUser.CustomTarget( 0, GetDictionaryEntry( 8255, socket.language )); // Select NPC to turn remotely using xturn:
 }
 
 function onCallback0( socket, myTarget )
@@ -64,12 +64,12 @@ function onCallback0( socket, myTarget )
 	if( !socket.GetWord( 1 ) && ValidateObject( myTarget ) && myTarget.isChar )
 	{
 		socket.tempObj = myTarget;
-  		var targMsg = GetDictionaryEntry( 8245, socket.language ); // Select movement (%s) destination:
+  		var targMsg = GetDictionaryEntry( 8256, socket.language ); // Select movement (%s) destination:
 		pUser.CustomTarget( 1, targMsg.replace( /%s/gi, socket.xText ));
 	}
 	else
 	{
-		pUser.SysMessage( GetDictionaryEntry( 8246, socket.language )); // You must target an NPC!
+		pUser.SysMessage( GetDictionaryEntry( 8257, socket.language )); // You must target an NPC!
 	}
 }
 
@@ -110,7 +110,7 @@ function onCallback1( socket, myTarget )
 				}
 			}
 
-  			var targMsg = GetDictionaryEntry( 8245, socket.language ); // Select movement (%s) destination:
+  			var targMsg = GetDictionaryEntry( 8256, socket.language ); // Select movement (%s) destination:
 			pUser.CustomTarget( 1, targMsg.replace( /%s/gi, socket.xText ));
 		}
 	}

--- a/data/js/server/global.js
+++ b/data/js/server/global.js
@@ -222,3 +222,17 @@ function onDeath( pDead, iCorpse )
 
 	return TriggerEvent( 5045, "onDeath", pDead, iCorpse );
 }
+
+// Triggers based on bandage macro in client
+function onUseBandageMacro( pSock, targChar, bandageItem )
+{
+	if( pSock != null && ValidateObject( targChar ) && ValidateObject( bandageItem ) && bandageItem.amount >= 1 )
+	{
+		var pUser = pSock.currentChar;
+		if( ValidateObject( pUser ))
+		{
+			TriggerEvent( 4000, "onUseCheckedTriggered", pUser, targChar, bandageItem );
+		}
+	}
+	return true;
+}

--- a/data/js/skill/healing.js
+++ b/data/js/skill/healing.js
@@ -1,3 +1,13 @@
+// Main Sources
+// 	Publish 71 - https://wiki.stratics.com/index.php?title=UO:Publish_Notes_from_2011-07-21
+
+// Secondary Sources
+// 	UOR era and earlier: https://web.archive.org/web/20010608154433/http://uo.stratics.com/content/skills/healing.shtml
+// 	LBR era: https://web.archive.org/web/20020806222303/http://uo.stratics.com:80/content/skills/healing.shtml
+// 	AoS era: https://web.archive.org/web/20030605153924/http://uo.stratics.com:80/content/skills/healing.shtml
+// 	ML/SA era: https://web.archive.org/web/20080718013839/http://uo.stratics.com/content/skills/healing.php
+// 	HS era: https://web.archive.org/web/20101229122433/http://uo.stratics.com/content/skills/healing.php
+
 // Trolls, Cyclopes, Ophidians, Ogres, Ettins, Orcs, Harpies, Headlesses, Lizardmen, Ratmen, Humans
 // , Human Players, Gargoyle players, Elf players, Juka, Meer, Pixies, Succubi, Centaur, Ethereal Warriors,
 const validHealTargets = [ 0x0190,0x0191,0x025d,0x025e,0x029a,0x029b,0x0001,0x0002,0x0007,0x0011,0x0012,
@@ -19,6 +29,26 @@ const validVetTargets = [ 0x0004,0x0005,0x0006,0x0008,0x000b,0x000c,0x0014,0x001
 		0x00d5,0x00d6,0x00d8,0x00d9,0x00da,0x00db,0x00dc,0x00dd,0x00e1,0x00e2,0x00e4,0x00e8,0x00ea,0x00ed,
 		0x00ee,0x00f3,0x00fd,0x00fe,0x0114,0x0115,0x0116,0x0117,0x0122,0x0123,0x0124,0x02f1,0x02f2,0x02f3,
 		0x02f6,0x030b,0x030c,0x0315,0x0317,0x031a,0x031f ];
+
+// If CoreShardEra is set to T2A or lower, skillgain from healing damage caps out at ~65.0
+// Further increases in skill have to come from curing poison (60-80)
+// and resurrecting (80-100+)
+const coreShardEra = GetServerSetting( "CoreShardEra" );
+const healingSkillGainCap = 650;
+const cureSkillGainCap = 850;
+
+// If set to 1, overrides the cap of 65.0 healing normally used when coreShardEra is set to T2A or lower
+// and instead uses actual skill cap
+const overrideCappedT2AHealing = 0;
+
+// Set to specific distance value to override max range regardless of era
+const overrideMaxBandageRange = 0;
+
+// If set to 1, scales difficulty of healing based on % of target health lost and on target's overall maxhp
+const useDifficultyScalingForHealing = 1;
+
+// This script's ID
+const healingScriptID = 4000;
 
 function onUseCheckedTriggered( pUser, targChar, iUsed )
 {
@@ -105,7 +135,8 @@ function onCallback1( socket, ourObj )
 
 	if( bItem && bItem.isItem && ourObj && ourObj.isChar && mChar && mChar.isChar )
 	{
-		if( mChar.InRange( ourObj, 2 ) && mChar.CanSee( ourObj ) && Math.abs( mChar.z - ourObj.z ) < 4 )
+		var maxRange = ( overrideMaxBandageRange ? overrideMaxBandageRange : ( coreShardEra >= EraStringToNum( "se" ) ? 2 : 1 )); // Range increased to 2 with SE expansion
+		if( mChar.InRange( ourObj, maxRange ) && mChar.CanSee( ourObj ) && Math.abs( mChar.z - ourObj.z ) < 4 )
 		{
 			if( ourObj.GetTempTag( "SK_BEINGHEALED" ))
 			{
@@ -163,166 +194,267 @@ function onCallback1( socket, ourObj )
 				}
 			}
 			var anatSkill = mChar.baseskills.anatomy;
+			var combinedCureHeal = false;
 			if( ourObj.dead ) // Resurrection
 			{
 				if( healSkill >= 800 && anatSkill >= 800 )
 				{
 					// Consume some bandages
-					if( bItem.amount > 1 )
-					{
-						bItem.amount = bItem.amount - 1;
-					}
-					else
-					{
-						bItem.Delete();
-					}
+					ConsumeBandage( bItem, 1 );
 
 					// Flag healer as criminal if target is murderer/criminal
-					if( ourObj.murderer || ourObj.criminal )
-					{
-						mChar.criminal = true;
-					}
+					FlagHealer( mChar, ourObj );
 
 					// Resurrecting takes between 8 - 10 seconds depending on dexterity
-					var healTimer = 10000 - (( mChar.dexterity / 50 ) * 1000 );
+					var healTimer = 0;
+					if( coreShardEra >= EraStringToNum( "uor" ))
+					{
+						// UOR introduced dexterity as a modifier for healing timer
+						healTimer = 10000 - (( mChar.dexterity / 50 ) * 1000 );
+					}
+					else// if( coreShardEra >= EraStringToNum( "t2a" ))
+					{
+						// T2A (Publish May 25, 1999), resurrecting "now" takes 10 seconds flat
+						healTimer = 10000;
+					}
+					/*else
+					{
+						// Did original UO have a different resurrect timer than T2A?
+						// ???
+					}*/
 					SetSkillInUse( socket, mChar, ourObj, skillNum, healTimer, true );
-					mChar.StartTimer( healTimer, 0, true );
+					mChar.StartTimer( healTimer, 0, healingScriptID );
 				}
 				else
 				{
 					socket.SysMessage( GetDictionaryEntry( 1493, socket.language )); // You are not skilled enough to resurrect.
 				}
+				return;
 			}
-			else if( ourObj.poison > 0 )	// Cure Poison
+			else if( ourObj.poison > 0 || ourObj.GetTempTag( "doBleed" ))	// Cure Poison/Bleed
 			{
-				if( healSkill >= 600 && anatSkill >= 600 )
+				if( mChar.serial == ourObj.serial && ourObj.health < ourObj.maxhp
+					&& coreShardEra >= EraStringToNum( "hs" ) && healSkill >= 800 && anatSkill >= 800 )
+				{
+					// When targeting self, attempt to remove poison/bleed at half the normal healing duration,
+					// but with reduced amount healed after finishing normal heal duration
+					combinedCureHeal = true;
+				}
+				else if( healSkill >= 600 && anatSkill >= 600 )
 				{
 					// Consume some bandages
-					if( bItem.amount > 1 )
-					{
-						bItem.amount = bItem.amount - 1;
-					}
-					else
-					{
-						bItem.Delete();
-					}
+					ConsumeBandage( bItem, 1 );
 
 					// Flag healer as criminal if target is murderer/criminal
-					if( ourObj.murderer || ourObj.criminal )
-					{
-						mChar.criminal = true;
-					}
+					FlagHealer( mChar, ourObj );
 
-					var healTimer;
+					var cureTimer;
 					if( mChar.serial == ourObj.serial )
 					{
-						// Curing Self takes 13 to 18 seconds depending on dexterity
-						healTimer = 18000 - (( mChar.dexterity / 20 ) * 1000);
+						if( coreShardEra >= EraStringToNum( "hs" ))
+						{
+							// HS+: curing self: 10 to 15 seconds
+							cureTimer = 15000 - (( mChar.dexterity / 24 ) * 1000 );
+						}
+						else if( coreShardEra >= EraStringToNum( "aos" ))
+						{
+							// AOS: Curing Self takes 9 to 15 seconds depending on dexterity
+							cureTimer = 15000 - (( mChar.dexterity / 20 ) * 1000 );
+						}
+						else if( coreShardEra >= EraStringToNum( "uor" ))
+						{
+							// UOR: Curing Self takes 13 to 18 seconds depending on dexterity
+							cureTimer = 18000 - (( mChar.dexterity / 24 ) * 1000 );
+						}
+						else
+						{
+							// T2A: Curing self takes 18 seconds flat
+							cureTimer = 18000;
+						}
 					}
 					else
 					{
-						// Curing others takes 4 to 6 seconds depending on dexterity
-						healTimer = 6000 - (( mChar.dexterity / 50 ) * 1000);
+						if( coreShardEra >= EraStringToNum( "hs" ))
+						{
+							// HS+: curing others: 3-5 seconds depending on dexterity
+							cureTimer = 5000 - (( mChar.dexterity / 40 ) * 1000 );
+						}
+						else if( coreShardEra >= EraStringToNum( "uor" ))
+						{
+							// UOR and later: Curing others takes 4 to 6 seconds depending on dexterity
+							cureTimer = 6000 - (( mChar.dexterity / 50 ) * 1000 );
+						}
+						else if( coreShardEra >= EraStringToNum( "t2a" ))
+						{
+							// T2A: Cure others takes 6 seconds flat
+							cureTimer = 6000;
+						}
+						else
+						{
+							// Original UO
+							cureTimer = 18000; // Curing self/others takes 18 seconds
+						}
 					}
 
-					SetSkillInUse( socket, mChar, ourObj, skillNum, healTimer, true );
-					mChar.StartTimer( healTimer, 1, true );
+					// Cut cure timer in two if we're trying to "cure" a bleed (which only lasts 10 seconds)
+					if( ourObj.GetTempTag( "doBleed" ))
+					{
+						cureTimer /= 2;
+					}
+
+					SetSkillInUse( socket, mChar, ourObj, skillNum, cureTimer, true );
+					mChar.StartTimer( cureTimer, 1, healingScriptID );
 				}
 				else
 				{
 					socket.SysMessage( GetDictionaryEntry( 1495, socket.language )); // You are not skilled enough to cure poison.
 					socket.SysMessage( GetDictionaryEntry( 1496, socket.language )); // The poison in your target's system counters the bandage's effect.
 				}
-
+				return;
 			}
 			else if( ourObj.health == ourObj.maxhp )
 			{
 				socket.SysMessage( GetDictionaryEntry( 1497, socket.language )); // That being is undamaged.
+				return;
 			}
-			else // Heal
+
+			// Mortal Strike effect prevents healing attempts
+			if( ourObj.GetTempTag( "blockHeal" ) == true )
 			{
-
-				if( ourObj.GetTempTag( "blockHeal" ) == true )
-				{
-					if( ourObj != mChar && ourObj.socket )
-					{
-						socket.SysMessage( "You cannot heal that target in their current state." );
-					}
-					else
-					{
-						socket.SysMessage( GetDictionaryEntry( 9058, socket.language ));// You can not heal yourself in your current state.
-					}
-				}
-				else if( ourObj.GetTempTag( "doBleed" ) == true )
-				{
-					if( ourObj != mChar && ourObj.socket ) 
-					{
-						socket.SysMessage( "You bind the wound and stop the bleeding" );
-					}
-					else
-					{
-						socket.SysMessage( "The bleeding wounds have healed, you are no longer bleeding!" );
-					}
-					ourObj.KillJSTimer( 9300, 7001 );
-					ourObj.SetTempTag( "doBleed", null );
-				}
-
-				// Consume some bandages
-				if( bItem.amount > 1 )
-				{
-					bItem.amount = bItem.amount - 1;
-				}
-				else
-				{
-					bItem.Delete();
-				}
-
-				// Flag healer as criminal if target is murderer/criminal
-				if( ourObj.murderer || ourObj.criminal )
-				{
-					mChar.criminal = true;
-				}
-
-				// Inform the target
 				if( ourObj != mChar && ourObj.socket )
 				{
-					var tempMsg = GetDictionaryEntry( 6016, ourObj.socket.language ); // %s is attempting to heal you.
-					ourObj.SysMessage( tempMsg.replace( /%s/gi, mChar.name ));
-				}
-
-				var healTimer;
-				if( mChar.serial == ourObj.serial )
-				{
-					// Healing self takes 11 to 15 seconds, depending on dexterity
-					healTimer = 15000 - (( mChar.dexterity / 20 ) * 1000 );
+					socket.SysMessage( "You cannot heal that target in their current state." );
 				}
 				else
 				{
-					// Healing others takes 3 to 5 seconds, depending on dexterity
+					socket.SysMessage( GetDictionaryEntry( 9058, socket.language ));// You can not heal yourself in your current state.
+				}
+				return;
+			}
+
+			// Consume some bandages
+			ConsumeBandage( bItem, 1 );
+
+			// Flag healer as criminal if target is murderer/criminal
+			FlagHealer( mChar, ourObj );
+
+			// Inform the target
+			if( ourObj != mChar && ourObj.socket )
+			{
+				var tempMsg = GetDictionaryEntry( 6016, ourObj.socket.language ); // %s is attempting to heal you.
+				ourObj.SysMessage( tempMsg.replace( /%s/gi, mChar.name ));
+			}
+
+			var healTimer;
+			if( mChar.serial == ourObj.serial )
+			{
+				// Healing self
+				if( coreShardEra >= EraStringToNum( "hs" ))
+				{
+					// HS and beyond, healing self takes 5 - 8 seconds (max duration reduced with Publish 71)
+					healTimer = 8000 - (( mChar.dexterity / 50 ) * 1000 );
+				}
+				else if( coreShardEra >= EraStringToNum( "ml" ))
+				{
+					// ML and beyond: Healing self takes 4 to 11 seconds
+					healTimer = 11000 - (( mChar.dexterity / 17.12 ) * 1000 )
+				}
+				else if( coreShardEra >= EraStringToNum( "se" ))
+				{
+					// SE: Healing self takes 5 to 10 seconds (Publish 21)
+					healTimer = 10000 - (( mChar.dexterity / 24 ) * 1000 );
+				}
+				else if( coreShardEra >= EraStringToNum( "aos" ))
+				{
+					// AOS: Healing self takes 9 to 16 seconds
+					healTimer = ( 9.4 + ( 0.6 * (( 120 - mChar.dexterity ) / 10 )));
+				}
+				else if( coreShardEra >= EraStringToNum( "uor" ))
+				{
+					// T2A to LBR: Healing self takes 11 to 15 seconds
+					healTimer = ( 11 + ( 0.4 * (( 100 - mChar.dexterity ) / 10 )));
+				}
+				else
+				{
+					// Original UO/T2A: Healing self takes 15 seconds flat
+					healTimer = 15000;
+				}
+			}
+			else
+			{
+				// Healing others
+				if( coreShardEra >= EraStringToNum( "ml" ))
+				{
+					// ML and beyond: healing others takes 2 to 4 seconds (4 - ( dex / 60 ))
+					healTimer = 4000 - (( mChar.dexterity / 60 ) * 1000 );
+				}
+				else if( coreShardEra >= EraStringToNum( "uor" ))
+				{
+					// AoS and earlier: Healing others takes 3 to 5 seconds, depending on dexterity
 					healTimer = 5000 - (( mChar.dexterity / 50 ) * 1000 );
 				}
-
-				mChar.AddScriptTrigger( 4014 ); // Add healing_slip.js script
-				SetSkillInUse( socket, mChar, ourObj, skillNum, healTimer, true );
-
-				// Add buff to target or yourself
-				var seconds = Math.round(healTimer / 1000);
-				if( ourObj != mChar && ourObj.socket )
+				else if( coreShardEra >= EraStringToNum( "t2a" ))
 				{
-					TriggerEvent( 2204, "AddBuff", ourObj, buffIcon, priCliloc, scndCliloc, seconds, " " + ourObj.name );
+					// t2a: Healing others takes 5 seconds flat (Publish May 25, 1999)
+					healTimer = 5000;
 				}
 				else
 				{
-					TriggerEvent( 2204, "AddBuff", mChar, buffIcon, priCliloc, scndCliloc, seconds, " " + ourObj.name );
+					// Original UO
+					healTimer = 15000; // Healing self/others takes 15 seconds flat
 				}
-
-				mChar.StartTimer( healTimer, 2, true );
 			}
+
+			mChar.AddScriptTrigger( 4014 ); // Add healing_slip.js script
+			SetSkillInUse( socket, mChar, ourObj, skillNum, healTimer, true );
+
+			// Add buff to target or yourself
+			var seconds = Math.round( healTimer / 1000 );
+			if( ourObj != mChar && ourObj.socket )
+			{
+				TriggerEvent( 2204, "AddBuff", ourObj, buffIcon, priCliloc, scndCliloc, seconds, " " + ourObj.name );
+			}
+			else
+			{
+				TriggerEvent( 2204, "AddBuff", mChar, buffIcon, priCliloc, scndCliloc, seconds, " " + ourObj.name );
+			}
+
+			if( combinedCureHeal )
+			{
+				mChar.SetTempTag( "combinedCureHeal", true );
+				// Start a timer to attempt poison curing at half the regular healing time
+				mChar.StartTimer( healtimer / 2, 1, healingScriptID );
+			}
+			else
+			{
+				mChar.SetTempTag( "combinedCureHeal", null );
+			}
+			mChar.StartTimer( healTimer, 2, healingScriptID );
 		}
 		else
 		{
 			socket.SysMessage( GetDictionaryEntry( 1498, socket.language )); // You are not close enough to apply the bandages.
 		}
+	}
+}
+
+function ConsumeBandage( bItem, amt )
+{
+	if( bItem.amount > amt )
+	{
+		bItem.amount = bItem.amount - amt;
+	}
+	else
+	{
+		bItem.Delete();
+	}
+}
+
+function FlagHealer( mChar, ourObj )
+{
+	if( ourObj.murderer || ourObj.criminal )
+	{
+		mChar.criminal = true;
 	}
 }
 
@@ -377,14 +509,34 @@ function SetSkillInUse( socket, mChar, ourObj, skillNum, healingTime, setVal )
 
 function onTimer( mChar, timerID )
 {
+	if( !ValidateObject( mChar ))
+		return;
+
+	var ourObj = CalcCharFromSer( mChar.GetTempTag( "SK_HEALINGTARG" ));
+	if( !ValidateObject( ourObj ))
+		return;
+
 	var skillNum = mChar.GetTempTag("SK_HEALINGTYPE");
-	var skillCap = null;
+	var primarySkill = 0;
+	var secondarySkill = 0;
+	var primarySkillCap = 0;
+	var secondarySkillCap = 0;
 	switch( skillNum )
 	{
-		case 17: skillCap = mChar.skillCaps.healing; break;
-		case 39: skillCap = mChar.skillCaps.veterinary; break;
+		case 17:
+			primarySkill = mChar.skills.healing;
+			secondarySkill = mChar.skills.anatomy;
+			primarySkillCap = mChar.skillCaps.healing;
+			secondarySkillCap = mChar.skillCaps.anatomy;
+			break;
+		case 39:
+			primarySkill = mChar.skills.veterinary;
+			secondarySkill = mChar.skills.animallore;
+			primarySkillCap = mChar.skillCaps.veterinary;
+			secondarySkillCap = mChar.skillCaps.animallore;
+			break;
 	}
-	var ourObj = CalcCharFromSer( mChar.GetTempTag( "SK_HEALINGTARG" ));
+
 	var socket = mChar.socket;
 	if( socket != null )
 	{
@@ -394,6 +546,7 @@ function onTimer( mChar, timerID )
 			return;
 		}
 
+		var maxRange = ( overrideMaxBandageRange ? overrideMaxBandageRange : ( coreShardEra >= EraStringToNum( "se" ) ? 2 : 1 )); // Range increased to 2 with SE expansion
 		if( !ValidateObject( ourObj ))
 		{
 			return;
@@ -402,7 +555,7 @@ function onTimer( mChar, timerID )
 		{
 			socket.SysMessage( GetDictionaryEntry( 9086, socket.language )); // You cannot heal that which is not alive.
 		}
-		else if( mChar.InRange( ourObj, 2 ) && mChar.CanSee( ourObj ))
+		else if( mChar.InRange( ourObj, maxRange ) && mChar.CanSee( ourObj ))
 		{
 			switch ( timerID )
 			{
@@ -410,9 +563,24 @@ function onTimer( mChar, timerID )
 					if( !ourObj.dead )
 					{
 						socket.SysMessage( GetDictionaryEntry( 9085, socket.language )); // The target is not dead.
+						break;
 					}
-					else if( mChar.CheckSkill( skillNum, 800, skillCap ) && mChar.CheckSkill( 1, 800, mChar.skillCaps.anatomy ))
+
+					// Base 25% chance to resurrect at 80.0 healing and 80.0 anatomy
+					// Base 65% chance to resurrect at 100.0 healing and 100.0 anatomy
+					// Base 100% (clamped) chance to resurrect at 120.0 healing and 120.0 anatomy
+					var chanceToRes = 0.25 + (((( primarySkill + secondarySkill ) / 2 ) - 800 ) * 0.002 );
+
+					// Reduce chance by 2% per number of times healer's fingers "slipped" during bandaging
+					chanceToRes -= ( mChar.GetTempTag( "slipCount" ) * 0.02 );
+
+					// Clamp at 0.0 - 1.0
+					chanceToRes = Math.max( 0.0, Math.min( 1.0, chanceToRes ));
+
+					var resResult = -1;
+					if( chanceToRes >= RandomNumber( 0.0, 1.0 ))
 					{
+						// Arise, and live!
 						var iMulti = ourObj.multi;
 						if( ValidateObject( iMulti ) && ( !iMulti.IsOnOwnerList( mChar ) && !iMulti.IsOnFriendList( mChar )) &&
 							( !iMulti.IsOnOwnerList( ourObj ) && !iMulti.IsOnFriendList( ourObj )))
@@ -427,42 +595,131 @@ function onTimer( mChar, timerID )
 							ourObj.StaticEffect( 0x376A, 10, 16 );
 							ourObj.SoundEffect( 0x214, true );
 							socket.SysMessage( GetDictionaryEntry( 1272, socket.language )); // You successfully resurrected the patient!
+							resResult = 1;
 						}
 					}
 					else
 					{
 						socket.SysMessage( GetDictionaryEntry( 9084, socket.language )); // You are unable to resurrect your patient.
 					}
+
+					// Run skill checks for chance to gain skill, but override the check to match up with the manual check done above, so a success is still a success, and a failure is still a failure
+					mChar.CheckSkill( skillNum, 800, primarySkillCap, false, resResult ); // Primary skill
+					mChar.CheckSkill(( skillNum == 17 ? 1 : 2 ), 800, secondarySkillCap, false, resResult ); // Secondary skill
+
 					break;
 				case 1:	// Cure Poison
-					if( mChar.CheckSkill( skillNum, 600, skillCap ) && (( skillNum == 17 && mChar.CheckSkill( 1, 600, mChar.skillCaps.anatomy )) || ( skillNum == 39 && mChar.CheckSkill( 2, 600, pUser.skillCaps.animallore ))))
+					var chanceToCure = 0;
+					var cureBleed = ourObj.GetTempTag( "doBleed" );
+					var combinedCureHeal = mChar.GetTempTag( "combinedCureHeal" );
+					if( combinedCureHeal )
 					{
-						ourObj.SetPoisoned( 0, 0 );
-						ourObj.StaticEffect( 0x373A, 0, 15 );
-						ourObj.SoundEffect( 0x01E0, true );
-						socket.SysMessage( GetDictionaryEntry( 1274, socket.language )); // You have cured the poison.
-						var objSock = ourObj.socket;
-						if( objSock )
+						// Chance for a "half heal duration" cure
+						chanceToCure = (((( primarySkill + secondarySkill ) / 10 ) - 120 ) * 25 ) / ( ourObj.poison * 20 );
+					}
+					else
+					{
+						// Base 80% chance to cure level 1 poison at 60.0 healing and 60.0 anatomy
+						// Base 92% chance at 100.0 healing and 100.0 anatomy
+						// Base 100% (clamped) chance at 120.0 healing and 120.0 anatomy
+						chanceToCure = 0.80 + (((( primarySkill + secondarySkill ) / 2 ) - 600 ) * 0.00035 );
+
+						// Reduce chance by 10% per poison level on target
+						chanceToCure -= ((( cureBleed ? 3 : ourObj.poison ) - 1 ) * 0.1 );
+					}
+
+					// Reduce chance by 2% per number of times healer's fingers "slipped" during bandaging
+					chanceToCure -= ( mChar.GetTempTag( "slipCount" ) * 0.02 );
+
+					// Clamp at 0.0 - 1.0
+					chanceToCure = Math.max( 0.0, Math.min( 1.0, chanceToCure ));
+
+					var cureResult = -1;
+					if( chanceToCure >= RandomNumber( 0.0, 1.0 ))
+					{
+						// Cured!
+						cureResult = 1;
+						if( combinedCureHeal )
 						{
-							objSock.SysMessage( GetDictionaryEntry( 1273, objSock.language )); // You have been cured of poison.
+							// Update combined cure/heal tag to reflect level of poison that was cured
+							// we'll use this later in the heal-portion of the timer
+							mChar.SetTempTag( "combinedCureHeal", ourObj.poison );
+						}
+						if( cureBleed )
+						{
+							// Cure the Bleed!
+							if( ourObj != mChar && ourObj.socket )
+							{
+								socket.SysMessage( "You bind the wound and stop the bleeding" );
+							}
+							else
+							{
+								socket.SysMessage( "The bleeding wounds have healed, you are no longer bleeding!" );
+							}
+							ourObj.KillJSTimer( 9300, 7001 ); // Stop the bleed timer on target
+							ourObj.SetTempTag( "doBleed", null );
+						}
+						else
+						{
+							ourObj.SetPoisoned( 0, 0 );
+							ourObj.StaticEffect( 0x373A, 0, 15 );
+							ourObj.SoundEffect( 0x01E0, true );
+							socket.SysMessage( GetDictionaryEntry( 1274, socket.language )); // You have cured the poison.
+							var objSock = ourObj.socket;
+							if( objSock && objSock != myChar.socket ) // Don't spam the player
+							{
+								objSock.SysMessage( GetDictionaryEntry( 1273, objSock.language )); // You have been cured of poison.
+							}
 						}
 					}
 					else
 					{
+						mChar.SetTempTag( "combinedCureHeal", null );
 						socket.SysMessage( GetDictionaryEntry( 1494, socket.language )); // You fail to counter the poison.
 					}
+
+					// Run skill checks for chance to gain skill, but override the check to match up with the manual check done above, so a success is still a success, and a failure is still a failure
+					var useSkillGainCaps = ( !overrideCappedT2AHealing && coreShardEra <= EraStringToNum( "t2a" ));
+					mChar.CheckSkill( skillNum, 600, ( useSkillGainCaps ? cureSkillGainCap : primarySkillCap ), false, cureResult ); // Primary skill
+					mChar.CheckSkill(( skillNum == 17 ? 1 : 2 ), 600, ( useSkillGainCaps ? cureSkillGainCap : secondarySkillCap ), false, cureResult ); // Secondary skill
 					break;
 				case 2:	// Heal
+					var upperBound = 1000;
 					var healthLoss = ( ourObj.maxhp - ourObj.health );
 					if( healthLoss == 0 )
 					{
 						socket.SysMessage( GetDictionaryEntry( 1497, socket.language )); // That being is undamaged.
+						mChar.SetTempTag( "combinedCureHeal", null );
+						break;
 					}
-					else if( mChar.CheckSkill( skillNum, 0, healthLoss * 10 )) // Requires higher and higher amount of health lost in order for healer to gain skill
+
+					if( !overrideCappedT2AHealing && coreShardEra <= EraStringToNum( "t2a" ))
+					{
+						// T2A and earlier, skill-gain from normal healing caps out at around ~65.0
+						upperBound = healingSkillGainCap; // 650
+					}
+					else
+					{
+						// UOR and later, skill gain from normal healing caps out at actual skill cap
+						upperBound = primarySkillCap;
+					}
+
+					if( useDifficultyScalingForHealing )
+					{
+						// Scale difficulty based on %loss of health on target + maxHP
+						// i.e. requires higher and higher amount of health lost in order for healer to gain skill
+						var normalizedHealthLoss = healthLoss / ourObj.maxhp; // get a value between 0.0 and 1.0
+						var idealHealAmtPerSkill = Math.max( 10, primarySkill * 0.155 );
+						var healTrainingEffectiveness = Math.min( 1.0, ourObj.maxhp / idealHealAmtPerSkill );
+						upperBound = Math.min( upperBound, Math.round( normalizedHealthLoss * primarySkillCap * healTrainingEffectiveness ));
+					}
+
+					// Perform skill check
+					if( mChar.CheckSkill( skillNum, 0, upperBound ))
 					{
 						var mItem;
-						var healBonus;
-						for( mItem = mChar.FirstItem(); !mChar.FinishedItems(); mItem = mChar.NextItem() ) 
+						var healBonus = 0;
+						for( mItem = mChar.FirstItem(); !mChar.FinishedItems(); mItem = mChar.NextItem() )
 						{
 							if( !ValidateObject( mItem ))
 								continue;
@@ -477,28 +734,22 @@ function onTimer( mChar, timerID )
 						}
 
 						// Are we healing using the Healing skill, or using the Veterinary skill?
-						var healSkill;
-						var secondarySkill;
 						if( skillNum == 17 ) // Healing
 						{
-							healSkill = mChar.skills.healing;
-							secondarySkill = mChar.skills.anatomy;
-
 							// Perform generic Anatomy skill check to allow skill increase
-							mChar.CheckSkill( 1, 0, mChar.skillCaps.anatomy );
+							mChar.CheckSkill( 1, 0, secondarySkillCap );
 						}
 						else if( skillNum == 39 ) // Veterinary
 						{
-							healSkill = mChar.skills.veterinary;
-							secondarySkill = mChar.skills.animallore;
-
 							// Perform generic Animal Lore skill check to allow skill increase
-							mChar.CheckSkill( 2, 0, mChar.skillCaps.animallore );
+							mChar.CheckSkill( 2, 0, secondarySkillCap );
 						}
 
-						// Retrieve amount of times character's hands slipped during healing
 						mChar.RemoveScriptTrigger( 4014 ); // Remove healing_slip.js script
+						// Retrieve amount of times character's hands slipped during healing
 						var slipCount = mChar.GetTempTag( "slipCount" );
+						mChar.SetTempTag( "slipCount", null );
+
 						if( slipCount > 5 )
 						{
 							// If hands slip more than 5 times, fail at healing
@@ -508,21 +759,46 @@ function onTimer( mChar, timerID )
 						else
 						{
 							// Minimum amount healed = Anatomy(or Animal Lore)/5 + Healing/5 + 3  Maximum amount healed = Anatomy(or Animal Lore)/5 + Healing/2 + 10
-							var minValue = Math.round(( secondarySkill / 50 ) + ( healSkill / 50 ) + 3 );
-							var maxValue = Math.round(( secondarySkill / 50 ) + ( healSkill / 20 ) + 10 );
+							var minValue = 0;
+							var maxValue = 0;
+							if( coreShardEra >= EraStringToNum( "se" ))
+							{
+								// SE and above, max heal at GM level is 36-60
+								minValue = Math.round(( secondarySkill / 80 ) + ( primarySkill / 50 ) + 4 );
+								maxValue = Math.round(( secondarySkill / 60 ) + ( primarySkill / 25 ) + 4 );
+							}
+							else
+							{
+								// AoS and below, max heal at GM level is 43-80
+								minValue = Math.round(( secondarySkill / 50 ) + ( primarySkill / 50 ) + 3 );
+								maxValue = Math.round(( secondarySkill / 50 ) + ( primarySkill / 20 ) + 10 );
+							}
 							var healAmt = RandomNumber( minValue, maxValue );
 
 							// Reduce the amount healed with each slip caused by damage taken while healing
+							// T2A and earlier, this amount is reduced by dexterity stat
+							// UOR and later, amount is reduced by dexterity stat & healing skill
+							var slipModifier = ( coreShardEra >= EraStringToNum( "uor" ) ? ( Math.round( primarySkill / 10 ) + mChar.dexterity ) : ( mChar.dexterity )) / 750;
 							for( var i = 0; i < slipCount; i++ )
 							{
-								// Reduce health by a percentage (35%) modified by healer's Healing skills and Dexterity for each slip up
-								healAmt -= Math.round( healAmt * ( 0.35 - (( Math.round( healSkill / 10 ) + mChar.dexterity ) / 750 )));
+								// Reduce healing done by a percentage (35%) modified by healer's Healing skills and Dexterity for each slip up
+								healAmt -= Math.round( healAmt * ( 0.35 - slipModifier ));
 
 								// Example: Healing reduction per slip, based a 35% percentage reduction, adjusted by 100.0 Healing and 100 Dexterity
 								// 80 > 74 > 68 > 63 > 58
 
-								// Example: Health reduction based on flat 35% percentage per slip
+								// Example: Healing reduction based on flat 35% percentage per slip
 								// 80 > 52 > 34 > 22 > 14
+							}
+
+							if( ourObj == mChar && coreShardEra >= EraStringToNum( "hs" ))
+							{
+								var poisonLvlCured = mChar.GetTempTag( "combinedCureHeal" );
+								if( poisonLvlCured > 0 )
+								{
+									// Reduce healing amount proportional to level of poison cured since we did a combined curing/healing action
+									healAmt /= poisonLvlCured;
+								}
 							}
 
 							if( healAmt <= 1 )
@@ -533,16 +809,12 @@ function onTimer( mChar, timerID )
 							}
 							else
 							{
-								ourObj.Heal(healAmt * (healBonus / 100), mChar );
+								ourObj.Heal( healAmt * Math.max( 1, ( 1 + ( healBonus / 100 ))), mChar );
 								socket.SysMessage( GetDictionaryEntry( 1271, socket.language )); // You apply the bandages and the patient looks a bit healthier.
 							}
 						}
 					}
-					else
-					{
-						socket.SysMessage( GetDictionaryEntry( 9089, socket.language )); // You finish applying the bandages, but they barely help.
-						ourObj.Heal( 1, mChar );
-					}
+					mChar.SetTempTag( "combinedCureHeal", null );
 					break;
 			}
 		}
@@ -551,5 +823,8 @@ function onTimer( mChar, timerID )
 			socket.SysMessage( GetDictionaryEntry( 6018, socket.language )); // You are no longer close enough to heal your target.
 		}
 	}
-	SetSkillInUse( socket, mChar, ourObj, skillNum, 0, false );
+	if( !mChar.GetTempTag( "combinedCureHeal" ))
+	{
+		SetSkillInUse( socket, mChar, ourObj, skillNum, 0, false );
+	}
 }

--- a/data/js/skill/healing.js
+++ b/data/js/skill/healing.js
@@ -69,7 +69,7 @@ function onUseChecked( pUser, iUsed )
 	if( ValidateObject( pUser ) && ValidateObject( iUsed ) && iUsed.isItem )
 	{
 		let socket = pUser.socket;
-		if( !ValidateObject( socket ))
+		if( socket == null )
 			return false;
 
 		let pLanguage = socket.language;
@@ -503,10 +503,10 @@ function onTimer( mChar, timerID )
 	if( !ValidateObject( mChar ))
 		return;
 
+	let skillNum = mChar.GetTempTag( "SK_HEALINGTYPE" );
 	let ourObj = CalcCharFromSer( mChar.GetTempTag( "SK_HEALINGTARG" ));
 	if( !ValidateObject( ourObj ))
 	{
-		let skillNum = mChar.GetTempTag( "SK_HEALINGTYPE" );
 		SetSkillInUse( socket, mChar, null, skillNum, 0, false );
 		return;
 	}
@@ -835,6 +835,12 @@ function onTimer( mChar, timerID )
 							}
 						}
 					}
+					else
+					{
+						// Skill Check failed
+						socket.SysMessage( GetDictionaryEntry( 9089, socket.language )); // You finish applying the bandages, but they barely help.
+					}
+
 					mChar.SetTempTag( "bonusCureLevel", null );
 					mChar.RemoveScriptTrigger( 4014 ); // Remove healing_slip.js script
 					mChar.SetTempTag( "slipCount", null );

--- a/data/js/skill/healing_slip.js
+++ b/data/js/skill/healing_slip.js
@@ -11,38 +11,41 @@ function onDamage( damaged, attacker, damageValue, damageType )
 		damaged.RemoveScriptTrigger( healSlipScriptID );
 	}
 
-	var slipOnPlayerDamage = 0;
-	var slipOnNPCDamage = 0;
-	if( coreShardEra >= EraStringToNum( "hs" ))
+	if( damageType != 7 ) // poison
 	{
-		// With Publish 71 for HS, threshold for slipping now scales by dexterity
-		slipOnPlayerDamage = 19 + Math.round( damaged.dexterity / 12 );
-		slipOnNPCDamage = 26 + Math.round( damaged.dexterity / 12 );
-	}
-	else if( coreShardEra >= EraStringToNum( "se" ))
-	{
-		// With Publish 21 for SE, threshold was raised to 26 hp for both PvP/PvE
-		// With Publish 25 for SE, threshold reduced from 26 to 19 for PvP only
-		slipOnPlayerDamage = 19;
-		slipOnNPCDamage = 26;
-	}
-	else
-	{
-		// Very low threshold for fingers slipping during bandaging in AoS? era and below
-		// Possibly supposed to be 0, no real values to be found
-		slipOnPlayerDamage = 2;
-		slipOnNPCDamage = 5;
-	}
-
-	// Only have player "slip up" at healing for high damage numbers
-	if( !ValidateObject( attacker ) ||
-		( damageValue >= slipOnNPCDamage && attacker.npc && !attacker.isHuman ) ||
-		( damageValue >= slipOnPlayerDamage && !attacker.npc ))
-	{
-		damaged.SetTempTag( "slipCount", damaged.GetTempTag( "slipCount" ) + 1 );
-		if( damaged.socket )
+		var slipOnPlayerDamage = 0;
+		var slipOnNPCDamage = 0;
+		if( coreShardEra >= EraStringToNum( "hs" ))
 		{
-			damaged.socket.SysMessage( GetDictionaryEntry( 9088, damaged.socket.language )); // Your fingers slip!
+			// With Publish 71 for HS, threshold for slipping now scales by dexterity
+			slipOnPlayerDamage = 19 + Math.round( damaged.dexterity / 12 );
+			slipOnNPCDamage = 26 + Math.round( damaged.dexterity / 12 );
+		}
+		else if( coreShardEra >= EraStringToNum( "se" ))
+		{
+			// With Publish 21 for SE, threshold was raised to 26 hp for both PvP/PvE
+			// With Publish 25 for SE, threshold reduced from 26 to 19 for PvP only
+			slipOnPlayerDamage = 19;
+			slipOnNPCDamage = 26;
+		}
+		else
+		{
+			// Very low threshold for fingers slipping during bandaging in AoS? era and below
+			// Possibly supposed to be 0, no real values to be found
+			slipOnPlayerDamage = 2;
+			slipOnNPCDamage = 5;
+		}
+
+		// Only have player "slip up" at healing for high damage numbers
+		if( !ValidateObject( attacker ) ||
+			( damageValue >= slipOnNPCDamage && attacker.npc && !attacker.isHuman ) ||
+			( damageValue >= slipOnPlayerDamage && !attacker.npc ))
+		{
+			damaged.SetTempTag( "slipCount", damaged.GetTempTag( "slipCount" ) + 1 );
+			if( damaged.socket )
+			{
+				damaged.socket.SysMessage( GetDictionaryEntry( 9088, damaged.socket.language )); // Your fingers slip!
+			}
 		}
 	}
 	return true;

--- a/data/js/skill/healing_slip.js
+++ b/data/js/skill/healing_slip.js
@@ -1,6 +1,5 @@
 const healSlipScriptID = 4014; // script ID assigned to this script in jse_fileassociations.scp
-const slipOnPlayerDamage = 19;
-const slipOnNPCDamage = 26;
+const coreShardEra = GetServerSetting( "CoreShardEra" );
 
 // For registering "slips" when attempting to heal someone with bandages
 function onDamage( damaged, attacker, damageValue, damageType )
@@ -10,6 +9,29 @@ function onDamage( damaged, attacker, damageValue, damageType )
 		// Player shouldn't have this script attached if they're not actively healing. Remove!
 		damaged.SetTempTag( "slipCount", null );
 		damaged.RemoveScriptTrigger( healSlipScriptID );
+	}
+
+	var slipOnPlayerDamage = 0;
+	var slipOnNPCDamage = 0;
+	if( coreShardEra >= EraStringToNum( "hs" ))
+	{
+		// With Publish 71 for HS, threshold for slipping now scales by dexterity
+		slipOnPlayerDamage = 19 + Math.Round( damaged.dexterity / 12 );
+		slipOnNPCDamage = 26 + Math.Round( damaged.dexterity / 12 );
+	}
+	else if( coreShardEra >= EraStringToNum( "se" ))
+	{
+		// With Publish 21 for SE, threshold was raised to 26 hp for both PvP/PvE
+		// With Publish 25 for SE, threshold reduced from 26 to 19 for PvP only
+		slipOnPlayerDamage = 19;
+		slipOnNPCDamage = 26;
+	}
+	else
+	{
+		// Very low threshold for fingers slipping during bandaging in AoS? era and below
+		// Possibly supposed to be 0, no real values to be found
+		slipOnPlayerDamage = 2;
+		slipOnNPCDamage = 5;
 	}
 
 	// Only have player "slip up" at healing for high damage numbers

--- a/data/js/skill/healing_slip.js
+++ b/data/js/skill/healing_slip.js
@@ -16,8 +16,8 @@ function onDamage( damaged, attacker, damageValue, damageType )
 	if( coreShardEra >= EraStringToNum( "hs" ))
 	{
 		// With Publish 71 for HS, threshold for slipping now scales by dexterity
-		slipOnPlayerDamage = 19 + Math.Round( damaged.dexterity / 12 );
-		slipOnNPCDamage = 26 + Math.Round( damaged.dexterity / 12 );
+		slipOnPlayerDamage = 19 + Math.round( damaged.dexterity / 12 );
+		slipOnNPCDamage = 26 + Math.round( damaged.dexterity / 12 );
 	}
 	else if( coreShardEra >= EraStringToNum( "se" ))
 	{

--- a/docs/jsdocs.html
+++ b/docs/jsdocs.html
@@ -3606,7 +3606,7 @@ function onSoldToVendor( pSock, Vendor, iSold, iAmount )
 					<div class="text-component">
 						<div class="settingsDiv">
 							<p><span class="hl">Prototype</span></p>
-							<p><em>function onSkillCheck( pUser, skillID, lowSkill, highSkill )</em></p>
+							<p><em>function onSkillCheck( pUser, skillID, lowSkill, highSkill, forceResult )</em></p>
 						</div>
 						<div class="settingsDiv">
 							<p><span class="hl">Purpose</span></p>
@@ -3625,11 +3625,11 @@ function onSoldToVendor( pSock, Vendor, iSold, iAmount )
 						</div>
 						<div class="settingsDiv">
 							<p><span class="hl">Notes</span></p>
-							<p>Runs just prior to skillcheck. lowSkill is minimum skill requirement for successful use of the skill (as passed into the skill check), while highSkill is the maximum skill the player can reach (as passed into the skill check)</p>
+							<p>Runs just prior to skillcheck. lowSkill is minimum skill requirement for successful use of the skill (as passed into the skill check), while highSkill is the maximum skill the player can reach (as passed into the skill check). forceResult will one of three values: -1 if result of skill check was forced to fail, 0 if a normal skillcheck was performed, and 1 if result of skill check was forced to succeed.</p>
 						</div>
 						<div class="settingsDiv">
 							<p><span class="hl">Example of usage</span><br>
-<pre><code class="language-javascript">function onSkillCheck( pUser, skillID, lowSkill, highSkill )
+<pre><code class="language-javascript">function onSkillCheck( pUser, skillID, lowSkill, highSkill, forceResult )
 {
 	pUser.TextMessage( "A skillcheck is being done for skill with ID " + skillID + "!" );
 	return false;
@@ -9280,6 +9280,7 @@ myNPC.CastSpell( 30, true );</code></pre>
 									<p><span class="hl">Prototype</span></p>
 									<p><em>bool CheckSkill( skillNum, minSkill, maxSkill )</em></p>
 									<p><em>bool CheckSkill( skillNum, minSkill, maxSkill, isCraftSkill )</em></p>
+									<p><em>bool CheckSkill( skillNum, minSkill, maxSkill, isCraftSkill, forceResult )</em></p>
 								</div>
 								<div class="settingsDiv">
 									<p><span class="hl">Purpose</span></p>
@@ -9287,7 +9288,7 @@ myNPC.CastSpell( 30, true );</code></pre>
 								</div>
 								<div class="settingsDiv">
 									<p><span class="hl">Notes</span></p>
-									<p>If the optional parameter isCraftSkill is set to true, UOX3 uses an alternate skill check formula that provides a minimum 50% chance of success if player at least meets minimum requirements for crafting an item</p>
+									<p>If the optional parameter isCraftSkill is set to true, UOX3 uses an alternate skill check formula that provides a minimum 50% chance of success if player at least meets minimum requirements for crafting an item. If the optional parameter forceResult is set to -1, the skillcheck result is forced to failure, 0 does nothing, and 1 forces a success.</p>
 								</div>
 								<div class="settingsDiv">
 									<p><span class="hl">Example of usage</span></p>

--- a/source/Changelog.txt
+++ b/source/Changelog.txt
@@ -1,3 +1,23 @@
+12/05/2025 - Xuri
+	Updated global script (js/server/global.js) to make use of onUseBandageMacro() to enable usage of bandage macros in client
+	Overhaul of Healing skill (js/skill/healing.js and js/skill/healing_slip.js) with fixes and improved era support. Script now includes some options that can be modified at top of script to override era-specific behavior. Summary of changes:
+		Healing actions are now difficulty based:
+			Resurrect chance scales from 25% (min 80.0 primary/secondary skill) to 65% at avg 100.0 skill to 100% at avg 120.0 skill
+			Cure chance scales from 80% (min 60.0 primary/secondary skill) to 92% at avg 100.0 skill and 100% at avg 120.0 skill, and is reduced by 10% per level of poison on target
+			Upper difficulty for Healing skill checks now changes based on % loss of health on target and based on its maxhp, so to continue gaining skills from healing, one needs to heal targets with higher and higher % of their health lost
+			For T2A core shard era, healing can only bring player to ~65.0 skill, curing can bring player from 60.0 to ~85.0 skill, and resurrection can bring player from 80.0 to 100+ skill.
+			For UOR and beyond, healing damage can bring player all the way to GM skill and beyond, without need to cure/resurrect
+		Base amount of damage healed with bandages in SE era and beyond adjusted to 36-60, compared to 43-80 for AoS and below
+		In HS era and beyond, min 80.0 primary and 80.0 secondary healing skill will now trigger attempt at curing poison/bleed at half normal heal duration (but with lower chance of success). If it succeeds, amount of health healed is reduced proportional to strength of poison cured. If it fails, another cure attempt is made after the heal.
+		Mortal Strike now blocks heal attempts on a target, but not attempts to cure poison/bleed
+		Fingers slipping due to being attacked while bandaging now has a higher threshold to take place for SE era and beyond, and scales further based on dexterity in HS era and beyond - while AOS era and below has a very low threshold for this
+	Updated .CheckSkill() Character JS Method to support another parameter which can force the result of a skillcheck (-1 = failure, 0 = use skillcheck result, 1 = success):
+		.CheckSkill( skillNum, minSkill, maxSkill[, isCraftSkill, forceResult ] )
+	Updated onSkillCheck() JS Event with another parameter, with the value of the optional forceResult parameter in CheckSkill()
+		onSkillCheck( pUser, skillID, lowSkill, highSkill, forceResult )
+	Fixed an issue where skill caps for player characters were not correctly initialized, resulting in unpredictable behavior
+	Fixed an issue with mana regen timer for MANAREGENMODE=1 (LBR and below) where timer was never adjusted
+
 08/05/2025 - Xuri
 	Added new JS Event that triggers when dismounting
 		onDismount( pUser, npcMount )

--- a/source/Changelog.txt
+++ b/source/Changelog.txt
@@ -18,6 +18,9 @@
 	Fixed an issue where skill caps for player characters were not correctly initialized, resulting in unpredictable behavior
 	Fixed an issue with mana regen timer for MANAREGENMODE=1 (LBR and below) where timer was never adjusted
 	Fix for pets getting stuck staring at potential targets in combat while simultaneously ignoring them
+	The damage of a weapon can now also be modified via the 'set damage # command. Supported syntax:
+		'set damage # // sets both lodamage and hidamage to value of #
+		'set damage # # // sets lowdamage to first value, hidamage to second value
 
 08/05/2025 - Xuri
 	Added new JS Event that triggers when dismounting

--- a/source/Changelog.txt
+++ b/source/Changelog.txt
@@ -17,6 +17,7 @@
 		onSkillCheck( pUser, skillID, lowSkill, highSkill, forceResult )
 	Fixed an issue where skill caps for player characters were not correctly initialized, resulting in unpredictable behavior
 	Fixed an issue with mana regen timer for MANAREGENMODE=1 (LBR and below) where timer was never adjusted
+	Fix for pets getting stuck staring at potential targets in combat while simultaneously ignoring them
 
 08/05/2025 - Xuri
 	Added new JS Event that triggers when dismounting

--- a/source/Changelog.txt
+++ b/source/Changelog.txt
@@ -21,6 +21,9 @@
 	The damage of a weapon can now also be modified via the 'set damage # command. Supported syntax:
 		'set damage # // sets both lodamage and hidamage to value of #
 		'set damage # # // sets lowdamage to first value, hidamage to second value
+	Added two new Admin commands to help address issues with player characters. Use sparingly!
+		'resetskillcaps // Resets ALL individual skillcaps for ALL player characters back to default
+		'resetskillusage // Resets skill usage status of all skills for ALL player characters to false, to unblock their use
 
 08/05/2025 - Xuri
 	Added new JS Event that triggers when dismounting

--- a/source/UOXJSMethods.cpp
+++ b/source/UOXJSMethods.cpp
@@ -4687,7 +4687,7 @@ JSBool CBase_StartTimer( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, 
 
 //o------------------------------------------------------------------------------------------------o
 //|	Function	-	CChar_CheckSkill()
-//|	Prototype	-	bool CheckSkill( skillnum, minskill, maxskill[, isCraftSkill] )
+//|	Prototype	-	bool CheckSkill( skillnum, minskill, maxskill[, isCraftSkill, forceResult] )
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Performs a skillcheck for character based on specified skill. Returns true
 //|					if result of skillcheck is between provided minimum and maximum values.
@@ -4699,7 +4699,7 @@ JSBool CChar_CheckSkill( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, 
 {
 	if( argc < 3 || argc > 5 )
 	{
-		ScriptError( cx, "CheckSkill: Invalid number of arguments (takes 3 to 5, skillNum, minSkill, maxSkill, isCraftSkill (optional) and overrideOutcome (optional))" );
+		ScriptError( cx, "CheckSkill: Invalid number of arguments (takes 3 to 5, skillNum, minSkill, maxSkill, isCraftSkill (optional) and forceResult (optional))" );
 		return JS_FALSE;
 	}
 
@@ -4715,16 +4715,16 @@ JSBool CChar_CheckSkill( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, 
 	UI16 minSkill = static_cast<UI16>( JSVAL_TO_INT( argv[1] ));
 	UI16 maxSkill = static_cast<UI16>( JSVAL_TO_INT( argv[2] ));
 	bool isCraftSkill = false;
-	SI08 overrideOutcome = 0;
+	SI08 forceResult = 0;
 	if( argc == 4 )
 	{
 		isCraftSkill = JSVAL_TO_BOOLEAN( argv[3] );
 	}
 	if( argc == 5 )
 	{
-		overrideOutcome = static_cast<SI08>( JSVAL_TO_INT( argv[4] ));
+		forceResult = static_cast<SI08>( JSVAL_TO_INT( argv[4] ));
 	}
-	*rval = BOOLEAN_TO_JSVAL( Skills->CheckSkill( myChar, skillNum, minSkill, maxSkill, isCraftSkill, overrideOutcome ));
+	*rval = BOOLEAN_TO_JSVAL( Skills->CheckSkill( myChar, skillNum, minSkill, maxSkill, isCraftSkill, forceResult ));
 	return JS_TRUE;
 }
 

--- a/source/UOXJSMethods.cpp
+++ b/source/UOXJSMethods.cpp
@@ -4697,9 +4697,9 @@ JSBool CBase_StartTimer( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, 
 //o------------------------------------------------------------------------------------------------o
 JSBool CChar_CheckSkill( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, jsval *rval )
 {
-	if( argc != 3 && argc != 4 )
+	if( argc < 3 || argc > 5 )
 	{
-		ScriptError( cx, "CheckSkill: Invalid number of arguments (takes 3 or 4, skillNum, minSkill, maxSkill and isCraftSkill (optional))" );
+		ScriptError( cx, "CheckSkill: Invalid number of arguments (takes 3 to 5, skillNum, minSkill, maxSkill, isCraftSkill (optional) and overrideOutcome (optional))" );
 		return JS_FALSE;
 	}
 
@@ -4715,11 +4715,16 @@ JSBool CChar_CheckSkill( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, 
 	UI16 minSkill = static_cast<UI16>( JSVAL_TO_INT( argv[1] ));
 	UI16 maxSkill = static_cast<UI16>( JSVAL_TO_INT( argv[2] ));
 	bool isCraftSkill = false;
+	SI08 overrideOutcome = 0;
 	if( argc == 4 )
 	{
 		isCraftSkill = JSVAL_TO_BOOLEAN( argv[3] );
 	}
-	*rval = BOOLEAN_TO_JSVAL( Skills->CheckSkill( myChar, skillNum, minSkill, maxSkill, isCraftSkill ));
+	if( argc == 5 )
+	{
+		overrideOutcome = static_cast<SI08>( JSVAL_TO_INT( argv[4] ));
+	}
+	*rval = BOOLEAN_TO_JSVAL( Skills->CheckSkill( myChar, skillNum, minSkill, maxSkill, isCraftSkill, overrideOutcome ));
 	return JS_TRUE;
 }
 
@@ -10854,7 +10859,7 @@ JSBool CChar_Heal( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, [[mayb
 		ScriptError( cx, "(CChar_Heal): Operating on an invalid Character" );
 		return JS_TRUE;
 	}
-	JSEncapsulate Heal( cx, &( argv[0] ));
+	SI16 healVal = static_cast<SI16>( JSVAL_TO_INT( argv[0] ));
 
 	if( argc == 2 )
 	{
@@ -10884,7 +10889,7 @@ JSBool CChar_Heal( JSContext *cx, JSObject *obj, uintN argc, jsval *argv, [[mayb
 	auto origScript = JSMapping->GetScript( JS_GetGlobalObject( cx ));
 	auto origScriptID = JSMapping->GetScriptId( JS_GetGlobalObject( cx ));
 
-	mChar->Heal( static_cast<SI16>( Heal.toInt() ), healer );
+	mChar->Heal( healVal, healer );
 
 	// Active script-context might have been lost, so restore it...
 	if( origScript != JSMapping->GetScript( JS_GetGlobalObject( cx )))

--- a/source/cChar.cpp
+++ b/source/cChar.cpp
@@ -295,6 +295,7 @@ npcGuild( DEFCHAR_NPCGUILD )
 	memset( &charTimers[0],		0, sizeof( TIMERVAL )	* tCHAR_COUNT );
 	memset( &baseskill[0],		0, sizeof( SKILLVAL )	* ALLSKILLS );
 	memset( &skill[0],			0, sizeof( SKILLVAL )	* ( INTELLECT + 1 ));
+	memset( &skillCap[0],		0, sizeof( SKILLVAL )	* ( INTELLECT + 1 ));
 
 	//SetCanTrain( true );
 	bools.set( BIT_TRAIN, true );

--- a/source/cScript.cpp
+++ b/source/cScript.cpp
@@ -3353,7 +3353,7 @@ SI08 cScript::OnSpellLoss( CItem *book, const UI08 spellNum )
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Triggers for character with event attached when a skillcheck is performed
 //o------------------------------------------------------------------------------------------------o
-SI08 cScript::OnSkillCheck( CChar *myChar, const UI08 skill, const UI16 lowSkill, const UI16 highSkill, bool isCraftSkill )
+SI08 cScript::OnSkillCheck( CChar *myChar, const UI08 skill, const UI16 lowSkill, const UI16 highSkill, bool isCraftSkill, SI08 overrideOutcome )
 {
 	const SI08 RV_NOFUNC = -1;
 	if( !ValidateObject( myChar ) || skill > ALLSKILLS )
@@ -3362,14 +3362,15 @@ SI08 cScript::OnSkillCheck( CChar *myChar, const UI08 skill, const UI16 lowSkill
 	if( !ExistAndVerify( seOnSkillCheck, "onSkillCheck" ))
 		return RV_NOFUNC;
 
-	jsval params[5], rval;
+	jsval params[6], rval;
 	JSObject *charObj = JSEngine->AcquireObject( IUE_CHAR, myChar, runTime );
 	params[0] = OBJECT_TO_JSVAL( charObj );
 	params[1] = INT_TO_JSVAL( skill );
 	params[2] = INT_TO_JSVAL( lowSkill );
 	params[3] = INT_TO_JSVAL( highSkill );
 	params[4] = BOOLEAN_TO_JSVAL( isCraftSkill );
-	JSBool retVal = JS_CallFunctionName( targContext, targObject, "onSkillCheck", 5, params, &rval );
+	params[5] = INT_TO_JSVAL( overrideOutcome );
+	JSBool retVal = JS_CallFunctionName( targContext, targObject, "onSkillCheck", 6, params, &rval );
 	if( retVal == JS_FALSE )
 	{
 		SetEventExists( seOnSkillCheck, false );

--- a/source/cScript.h
+++ b/source/cScript.h
@@ -257,7 +257,7 @@ public:
 	bool		OnSpeechInput( CChar *myChar, CItem *myItem, const char *mySpeech );
 	SI08		OnSpellGain( CItem *book, const UI08 spellNum );
 	SI08		OnSpellLoss( CItem *book, const UI08 spellNum );
-	SI08		OnSkillCheck( CChar *myChar, const UI08 skill, const UI16 lowSkill, const UI16 highSkill, bool isCraftSkill );
+	SI08		OnSkillCheck( CChar *myChar, const UI08 skill, const UI16 lowSkill, const UI16 highSkill, bool isCraftSkill, SI08 overrideOutcome );
 	SI08		OnDropItemOnNpc( CChar *srcChar, CChar *targChar, CItem *i );
 	SI08		OnDropItemOnItem( CItem *item, CChar *dropper, CItem *dest );
 	SI08		OnVirtueGumpPress( CChar *mChar, CChar *tChar, UI16 buttonId );

--- a/source/movement.cpp
+++ b/source/movement.cpp
@@ -3754,6 +3754,7 @@ auto CMovement::IgnoreAndEvadeTarget( CChar *mChar ) -> void
 			if( mTarget->GetTarg() == mChar )
 			{
 				mTarget->SetTarg( nullptr );
+				mTarget->SetWar( false );
 			}
 		}
 		mChar->SetTarg( nullptr );

--- a/source/skills.cpp
+++ b/source/skills.cpp
@@ -523,7 +523,7 @@ UI16 CSkills::CalculatePetControlChance( CChar *mChar, CChar *Npc )
 //|					with.  If skill is < than lowskill check will fail, but player will gain in the
 //|					skill, if the players skill is > than highskill player will not gain
 //o------------------------------------------------------------------------------------------------o
-bool CSkills::CheckSkill( CChar *s, UI08 sk, SI16 lowSkill, SI16 highSkill, bool isCraftSkill )
+bool CSkills::CheckSkill( CChar *s, UI08 sk, SI16 lowSkill, SI16 highSkill, bool isCraftSkill, SI08 overrideOutcome )
 {
 	bool skillCheck		= false;
 	bool exists			= false;
@@ -534,7 +534,7 @@ bool CSkills::CheckSkill( CChar *s, UI08 sk, SI16 lowSkill, SI16 highSkill, bool
 		if( toExecute != nullptr )
 		{
 			// If script returns true/1, allows skillcheck to proceed, but also prevents other scripts with event from running
-			if( toExecute->OnSkillCheck( s, sk, lowSkill, highSkill, isCraftSkill ) == 1 )
+			if( toExecute->OnSkillCheck( s, sk, lowSkill, highSkill, isCraftSkill, overrideOutcome ) == 1 )
 			{
 				exists = true;
 				break;
@@ -566,7 +566,7 @@ bool CSkills::CheckSkill( CChar *s, UI08 sk, SI16 lowSkill, SI16 highSkill, bool
 		CSocket *mSock = s->GetSocket();
 		R32 chanceSkillSuccess = 0;
 
-		if(( highSkill - lowSkill ) <= 0 || !ValidateObject( s ) || s->GetSkill( sk ) < lowSkill )
+		if( !ValidateObject( s ) || (( highSkill - lowSkill ) <= 0 || s->GetSkill( sk ) < lowSkill ))
 			return false;
 
 		if( s->IsDead() && mSock != nullptr )
@@ -575,53 +575,60 @@ bool CSkills::CheckSkill( CChar *s, UI08 sk, SI16 lowSkill, SI16 highSkill, bool
 			return false;
 		}
 
-		if( s->GetSkill( sk ) >= highSkill )
+		if( s->GetSkill( sk ) >= highSkill && overrideOutcome >= 0 )
 			return true;
 
-		// Calculate base chance of success at using a skill
-		chanceSkillSuccess = ( static_cast<R32>( s->GetSkill( sk )) - static_cast<R32>( lowSkill ));
-
-		// Modify chance based on the range of highSkill vs lowSkill
-		chanceSkillSuccess /= ( static_cast<R32>( highSkill ) - static_cast<R32>( lowSkill ));
-
-		// Let's work with whole numbers again
-		chanceSkillSuccess *= 1000;
-
-		if( isCraftSkill )
+		if( overrideOutcome != 0 )
 		{
-			// Give players at least 50% chance at success if this is a crafting skill and their skill is above minimum requirement
-			chanceSkillSuccess = std::max( static_cast<R32>( 500 ), chanceSkillSuccess );
-		}
-
-		// Cap chance of success at 1000 (100.0%)
-		chanceSkillSuccess = std::min( static_cast<R32>( 1000 ), chanceSkillSuccess );
-
-		if( cwmWorldState->ServerData()->StatsAffectSkillChecks() )
-		{
-			// Modify base chance of success with bonuses from stats, if this feature is enabled in ini
-			chanceSkillSuccess += static_cast<R32>( s->GetStrength() * cwmWorldState->skill[sk].strength ) / 1000.0f;
-			chanceSkillSuccess += static_cast<R32>( s->GetDexterity() * cwmWorldState->skill[sk].dexterity ) / 1000.0f;
-			chanceSkillSuccess += static_cast<R32>( s->GetIntelligence() * cwmWorldState->skill[sk].intelligence ) / 1000.0f;
-		}
-
-		// If player's command-level is equal to Counselor or higher, pass the skill-check automatically
-		// Same if chance of success is 100% already - no need to proceed!
-		if( s->GetCommandLevel() > 0 || chanceSkillSuccess == 1000 )
-		{
-			if( RandomNum( 1, 100 ) > 80 && s->GetCommandLevel() > 0 && mSock != nullptr )
-			{
-				// Inform the counselor/gm to make it obvious why skillcheck always succeeds
-				mSock->SysMessage( 6279 ); // Tip: Skill check success guaranteed due to elevated command level!
-			}
-			skillCheck = true;
+			skillCheck = ( overrideOutcome == 1 ? true : false );
 		}
 		else
 		{
-			// Generate a random number between 0 and highSkill (if less than 1000) or 1000 (if higher than 1000)
-			SI16 rnd = RandomNum( 0, std::min( 1000, ( highSkill + 100 )));
+			// Calculate base chance of success at using a skill
+			chanceSkillSuccess = ( static_cast<R32>( s->GetSkill( sk )) - static_cast<R32>( lowSkill ));
 
-			// Compare to chanceOfSkillSuccess to see if player succeeds!
-			skillCheck = ( static_cast<SI16>( chanceSkillSuccess ) >= rnd );
+			// Modify chance based on the range of highSkill vs lowSkill
+			chanceSkillSuccess /= ( static_cast<R32>( highSkill ) - static_cast<R32>( lowSkill ));
+
+			// Let's work with whole numbers again
+			chanceSkillSuccess *= 1000;
+
+			if( isCraftSkill )
+			{
+				// Give players at least 50% chance at success if this is a crafting skill and their skill is above minimum requirement
+				chanceSkillSuccess = std::max( static_cast<R32>( 500 ), chanceSkillSuccess );
+			}
+
+			// Cap chance of success at 1000 (100.0%)
+			chanceSkillSuccess = std::min( static_cast<R32>( 1000 ), chanceSkillSuccess );
+
+			if( cwmWorldState->ServerData()->StatsAffectSkillChecks() )
+			{
+				// Modify base chance of success with bonuses from stats, if this feature is enabled in ini
+				chanceSkillSuccess += static_cast<R32>( s->GetStrength() * cwmWorldState->skill[sk].strength ) / 1000.0f;
+				chanceSkillSuccess += static_cast<R32>( s->GetDexterity() * cwmWorldState->skill[sk].dexterity ) / 1000.0f;
+				chanceSkillSuccess += static_cast<R32>( s->GetIntelligence() * cwmWorldState->skill[sk].intelligence ) / 1000.0f;
+			}
+
+			// If player's command-level is equal to Counselor or higher, pass the skill-check automatically
+			// Same if chance of success is 100% already - no need to proceed!
+			if( s->GetCommandLevel() > 0 || chanceSkillSuccess == 1000 )
+			{
+				if( RandomNum( 1, 100 ) > 80 && s->GetCommandLevel() > 0 && mSock != nullptr )
+				{
+					// Inform the counselor/gm to make it obvious why skillcheck always succeeds
+					mSock->SysMessage( 6279 ); // Tip: Skill check success guaranteed due to elevated command level!
+				}
+				skillCheck = true;
+			}
+			else
+			{
+				// Generate a random number between 0 and highSkill (if less than 1000) or 1000 (if higher than 1000)
+				SI16 rnd = RandomNum( 0, std::min( 1000, ( highSkill + 100 )));
+
+				// Compare to chanceOfSkillSuccess to see if player succeeds!
+				skillCheck = ( static_cast<SI16>( chanceSkillSuccess ) >= rnd );
+			}
 		}
 
 		if( mSock != nullptr )

--- a/source/skills.cpp
+++ b/source/skills.cpp
@@ -523,7 +523,7 @@ UI16 CSkills::CalculatePetControlChance( CChar *mChar, CChar *Npc )
 //|					with.  If skill is < than lowskill check will fail, but player will gain in the
 //|					skill, if the players skill is > than highskill player will not gain
 //o------------------------------------------------------------------------------------------------o
-bool CSkills::CheckSkill( CChar *s, UI08 sk, SI16 lowSkill, SI16 highSkill, bool isCraftSkill, SI08 overrideOutcome )
+bool CSkills::CheckSkill( CChar *s, UI08 sk, SI16 lowSkill, SI16 highSkill, bool isCraftSkill, SI08 forceResult )
 {
 	bool skillCheck		= false;
 	bool exists			= false;
@@ -534,7 +534,7 @@ bool CSkills::CheckSkill( CChar *s, UI08 sk, SI16 lowSkill, SI16 highSkill, bool
 		if( toExecute != nullptr )
 		{
 			// If script returns true/1, allows skillcheck to proceed, but also prevents other scripts with event from running
-			if( toExecute->OnSkillCheck( s, sk, lowSkill, highSkill, isCraftSkill, overrideOutcome ) == 1 )
+			if( toExecute->OnSkillCheck( s, sk, lowSkill, highSkill, isCraftSkill, forceResult ) == 1 )
 			{
 				exists = true;
 				break;
@@ -566,7 +566,7 @@ bool CSkills::CheckSkill( CChar *s, UI08 sk, SI16 lowSkill, SI16 highSkill, bool
 		CSocket *mSock = s->GetSocket();
 		R32 chanceSkillSuccess = 0;
 
-		if( !ValidateObject( s ) || (( highSkill - lowSkill ) <= 0 || s->GetSkill( sk ) < lowSkill ))
+		if( !ValidateObject( s ) || (( highSkill - lowSkill ) <= 0 || ( s->GetSkill( sk ) < lowSkill && forceResult <= 0 )))
 			return false;
 
 		if( s->IsDead() && mSock != nullptr )
@@ -575,12 +575,12 @@ bool CSkills::CheckSkill( CChar *s, UI08 sk, SI16 lowSkill, SI16 highSkill, bool
 			return false;
 		}
 
-		if( s->GetSkill( sk ) >= highSkill && overrideOutcome >= 0 )
+		if( s->GetSkill( sk ) >= highSkill && forceResult >= 0 )
 			return true;
 
-		if( overrideOutcome != 0 )
+		if( forceResult != 0 )
 		{
-			skillCheck = ( overrideOutcome == 1 ? true : false );
+			skillCheck = ( forceResult == 1 ? true : false );
 		}
 		else
 		{

--- a/source/skills.h
+++ b/source/skills.h
@@ -172,7 +172,7 @@ public:
 	void Snooping( CSocket *s, CChar *target, CItem *pack );
 
 	UI16 CalculatePetControlChance( CChar *mChar, CChar *Npc );
-	bool CheckSkill( CChar *s, UI08 sk, SI16 lowSkill, SI16 highSkill, bool isCraftSkill = false );
+	bool CheckSkill( CChar *s, UI08 sk, SI16 lowSkill, SI16 highSkill, bool isCraftSkill = false, SI08 overrideOutcome = 0 );
 	void SkillUse( CSocket *s, UI08 x );
 	void UpdateSkillLevel( CChar *c, UI08 s) const;
 	void AdvanceStats( CChar *s, UI08 sk, bool skillsuccess );

--- a/source/skills.h
+++ b/source/skills.h
@@ -172,7 +172,7 @@ public:
 	void Snooping( CSocket *s, CChar *target, CItem *pack );
 
 	UI16 CalculatePetControlChance( CChar *mChar, CChar *Npc );
-	bool CheckSkill( CChar *s, UI08 sk, SI16 lowSkill, SI16 highSkill, bool isCraftSkill = false, SI08 overrideOutcome = 0 );
+	bool CheckSkill( CChar *s, UI08 sk, SI16 lowSkill, SI16 highSkill, bool isCraftSkill = false, SI08 forceResult = 0 );
 	void SkillUse( CSocket *s, UI08 x );
 	void UpdateSkillLevel( CChar *c, UI08 s) const;
 	void AdvanceStats( CChar *s, UI08 sk, bool skillsuccess );

--- a/source/uox3.cpp
+++ b/source/uox3.cpp
@@ -1579,7 +1579,7 @@ auto PassiveManaRegen( CSocket *mSock, CChar &mChar, UI16 maxMana ) -> SI32
 			R64 negativeEffect = ( armorWeight * normalizedArmor ) * 6.0;
 
 			// Calculate final time until next mana regen, in seconds
-			nextManaRegen = (( nextManaRegen / 1000 ) * ( 7.0 - positiveEffect + negativeEffect )) * 1000;
+			nextManaRegen = (( nextManaRegen / 1000 ) - positiveEffect + negativeEffect ) * 1000;
 
 			// Increment mana based on the calculated regeneration time
 			SI32 manaIncrement = mChar.IsMeditating() ? 2 : 1; // double if actively meditating


### PR DESCRIPTION
- Updated global script (js/server/global.js) to make use of onUseBandageMacro() to enable usage of bandage macros in client
- Overhaul of Healing skill (js/skill/healing.js and js/skill/healing_slip.js) with fixes and improved era support. Script now includes some options that can be modified at top of script to override era-specific behavior. Summary of changes:
  - Healing actions are now difficulty based:
    - Resurrect chance scales from 25% (min 80.0 primary/secondary skill) to 65% at avg 100.0 skill to 100% at avg 120.0 skill
    - Cure chance scales from 80% (min 60.0 primary/secondary skill) to 92% at avg 100.0 skill and 100% at avg 120.0 skill, and is reduced by 10% per level of poison on target
    - Upper difficulty for Healing skill checks now changes based on % loss of health on target and based on its maxhp, so to continue gaining skills from healing, one needs to heal targets with higher and higher % of their health lost
    - For T2A core shard era, healing can only bring player to ~65.0 skill, curing can bring player from 60.0 to ~85.0 skill, and resurrection can bring player from 80.0 to 100+ skill.
    - For UOR and beyond, healing damage can bring player all the way to GM skill and beyond, without need to cure/resurrect
  - Base amount of damage healed with bandages in SE era and beyond adjusted to 36-60, compared to 43-80 for AoS and below
  - In HS era and beyond, min 80.0 primary and 80.0 secondary healing skill will now trigger attempt at curing poison/bleed at half normal heal duration (but with lower chance of success). If it succeeds, amount of health healed is reduced proportional to strength of poison cured. If it fails, another cure attempt is made after the heal.
  - Mortal Strike now blocks heal attempts on a target, but not attempts to cure poison/bleed
  - Fingers slipping due to being attacked while bandaging now has a higher threshold to take place for SE era and beyond, and scales further based on dexterity in HS era and beyond - while AOS era and below has a very low threshold for this
- Updated .CheckSkill() Character JS Method to support another parameter which can force the result of a skillcheck (-1 = failure, 0 = use skillcheck result, 1 = success):
  - .CheckSkill( skillNum, minSkill, maxSkill[, isCraftSkill, forceResult ] )
- Updated onSkillCheck() JS Event with another parameter, with the value of the optional forceResult parameter in CheckSkill()
  - onSkillCheck( pUser, skillID, lowSkill, highSkill, forceResult )
- Fixed an issue where skill caps for player characters were not correctly initialized, resulting in unpredictable behavior
- Fixed an issue with mana regen timer for MANAREGENMODE=1 (LBR and below) where timer was never adjusted
- Fix for pets getting stuck staring at potential targets in combat while simultaneously ignoring them
- The damage of a weapon can now also be modified via the 'set damage # command. Supported syntax:
  - 'set damage # // sets both lodamage and hidamage to value of #
  - 'set damage # # // sets lowdamage to first value, hidamage to second value
- Added two new Admin commands to help address issues with player characters. Use sparingly!
  - 'resetskillcaps // Resets ALL individual skillcaps for ALL player characters back to default
  - 'resetskillusage // Resets skill usage status of all skills for ALL player characters to false, to unblock their use