### PR TITLE
Fix for skill calculation and int contribution to skill

### DIFF
--- a/source/Changelog.txt
+++ b/source/Changelog.txt
@@ -1,3 +1,7 @@
+14/05/2025 - Xuri
+	Fixed an issue where integer division and rounding of values could lead to skill gains not being visible to player
+	Fixed an issue where intelligence stat would not contribute to skill points based on skills.dfn setup the same way as dex/str
+
 12/05/2025 - Xuri
 	Updated global script (js/server/global.js) to make use of onUseBandageMacro() to enable usage of bandage macros in client
 	Overhaul of Healing skill (js/skill/healing.js and js/skill/healing_slip.js) with fixes and improved era support. Script now includes some options that can be modified at top of script to override era-specific behavior. Summary of changes:

--- a/source/skills.cpp
+++ b/source/skills.cpp
@@ -1166,7 +1166,7 @@ void CSkills::UpdateSkillLevel( CChar *c, UI08 s ) const
 	SI16 aInt = c->ActualIntelligence();
 	UI16 bSkill = c->GetBaseSkill( s );
 
-	UI16 temp = ((( sStr * aStr ) / 100 + ( sDex * aDex ) / 100 + ( sInt + aInt ) / 100) * ( 1000 - bSkill )) / 1000 + bSkill;
+	UI16 temp = (( static_cast<R32>( sStr * aStr ) / 100.0f + static_cast<R32>( sDex * aDex ) / 100.0f + static_cast<R32>( sInt * aInt ) / 100.0f ) * static_cast<R32>( 1000 - bSkill )) / 1000.0f + static_cast<R32>( bSkill );
 	c->SetSkill( std::max( bSkill, temp ), s );
 }
 


### PR DESCRIPTION
- Fixed an issue where integer division and rounding of values could lead to skill gains not being visible to player
- Fixed an issue where intelligence stat would not contribute to skill points based on skills.dfn setup the same way as dex/str