### PR TITLE
Bump timers to 64 bit

### DIFF
--- a/source/SEFunctions.cpp
+++ b/source/SEFunctions.cpp
@@ -286,7 +286,7 @@ JSBool SE_CheckTimeSinceLastCombat( JSContext* cx, [[maybe_unused]] JSObject* ob
 	timespanInSeconds = static_cast<UI32>( JSVAL_TO_INT( argv[1] ));
 
 	// Use GetGUITimerCurTime() instead of time(nullptr) for consistency
-	UI32 now = cwmWorldState->GetUICurrentTime();
+	TVAL now = cwmWorldState->GetUICurrentTime();
 
 	if(( now - from->GetLastCombatTime() ) < timespanInSeconds )
 	{

--- a/source/cChar.cpp
+++ b/source/cChar.cpp
@@ -6099,11 +6099,11 @@ void CChar::SetRobe( SERIAL newValue )
 //o------------------------------------------------------------------------------------------------o
 //| Purpose		-	Gets/Sets timestamp for when player last moved
 //o------------------------------------------------------------------------------------------------o
-UI32 CChar::LastMoveTime( void ) const
+TVAL CChar::LastMoveTime( void ) const
 {
 	return lastMoveTime;
 }
-void CChar::LastMoveTime( UI32 newValue )
+void CChar::LastMoveTime( TVAL newValue )
 {
 	lastMoveTime = newValue;
 }
@@ -6114,11 +6114,11 @@ void CChar::LastMoveTime( UI32 newValue )
 //o------------------------------------------------------------------------------------------------o
 //| Purpose		-	Gets/Sets timestamp for when player last combat
 //o------------------------------------------------------------------------------------------------o
-UI32 CChar::GetLastCombatTime() const
+TVAL CChar::GetLastCombatTime() const
 {
 	return lastCombatTime;
 }
-void CChar::SetLastCombatTime( UI32 newValue )
+void CChar::SetLastCombatTime( TVAL newValue )
 {
 	lastCombatTime = newValue;
 }
@@ -6184,7 +6184,7 @@ void CChar::SetLastOnSecs( UI32 newValue )
 //o------------------------------------------------------------------------------------------------o
 //| Purpose		-	Gets/Sets timestamp (in seconds) for when player character was created
 //o------------------------------------------------------------------------------------------------o
-UI32 CChar::GetCreatedOn( void ) const
+TVAL CChar::GetCreatedOn( void ) const
 {
 	UI32 rVal = 0;
 	if( IsValidPlayer() )
@@ -6193,7 +6193,7 @@ UI32 CChar::GetCreatedOn( void ) const
 	}
 	return rVal;
 }
-void CChar::SetCreatedOn( UI32 newValue )
+void CChar::SetCreatedOn( TVAL newValue )
 {
 	if( IsValidPlayer() )
 	{
@@ -7583,16 +7583,16 @@ void CChar::SetNPCGuild( UI16 newValue )
 //o------------------------------------------------------------------------------------------------o
 //| Purpose		-	Gets/Sets timestamp (in seconds) for when player character joined NPC guild
 //o------------------------------------------------------------------------------------------------o
-UI32 CChar::GetNPCGuildJoined( void ) const
+TVAL CChar::GetNPCGuildJoined( void ) const
 {
-	UI32 rVal = 0;
+	TVAL rVal = 0;
 	if( IsValidPlayer() )
 	{
 		rVal = mPlayer->npcGuildJoined;
 	}
 	return rVal;
 }
-void CChar::SetNPCGuildJoined( UI32 newValue )
+void CChar::SetNPCGuildJoined(TVAL newValue )
 {
 	if( IsValidPlayer() )
 	{

--- a/source/cChar.h
+++ b/source/cChar.h
@@ -48,7 +48,7 @@ enum cC_TID
 
 struct TargetInfo
 {
-	UI32 timestamp;
+	TVAL timestamp;
 	bool isNpc;
 };
 
@@ -168,8 +168,8 @@ private:
 		SERIAL		townVote;
 		SI08		townPriv;  //0=non resident (Other privledges added as more functionality added)
 		UI08		controlSlotsUsed; // The total number of control slots currently taken up by followers/pets
-		UI32		createdOn;	// Timestamp for when player character was created
-		UI32		npcGuildJoined;	// Timestamp for when player character joined NPC guild (0=never joined)
+		TVAL		createdOn;	// Timestamp for when player character was created
+		TVAL		npcGuildJoined;	// Timestamp for when player character joined NPC guild (0=never joined)
 		UI32		playTime;	// Character's full playtime
 
 		UI08		atrophy[INTELLECT+1];
@@ -839,17 +839,17 @@ public:
 	auto		GetPlayTime() const -> UI32;
 	auto		SetPlayTime( UI32 newValue ) -> void;
 
-	void		SetCreatedOn( UI32 newValue );
-	UI32		GetCreatedOn( void ) const;
+	void		SetCreatedOn( TVAL newValue );
+	TVAL		GetCreatedOn( void ) const;
 
-	void		SetNPCGuildJoined( UI32 newValue );
-	UI32		GetNPCGuildJoined( void ) const;
+	void		SetNPCGuildJoined( TVAL newValue );
+	TVAL		GetNPCGuildJoined( void ) const;
 
-	UI32		LastMoveTime( void ) const;
-	void		LastMoveTime( UI32 newValue );
+	TVAL		LastMoveTime( void ) const;
+	void		LastMoveTime( TVAL newValue );
 
-	UI32		GetLastCombatTime() const;
-	void		SetLastCombatTime(UI32 newValue);
+	TVAL		GetLastCombatTime() const;
+	void		SetLastCombatTime(TVAL newValue);
 
 
 	CChar *		GetTrackingTarget( void ) const;

--- a/source/cHTMLSystem.cpp
+++ b/source/cHTMLSystem.cpp
@@ -660,7 +660,7 @@ void cHTMLTemplate::Load( CScriptSection *found )
 
 		if( UTag == "UPDATE" )
 		{
-			updateTimer = static_cast<UI32>( std::stoul( data, nullptr, 0 ));
+			updateTimer = static_cast<TVAL>( std::stoul( data, nullptr, 0 ));
 		}
 		else if( UTag == "TYPE" )
 		{
@@ -868,7 +868,7 @@ std::string cHTMLTemplate::GetInput( void ) const
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets the next scheduled Update time
 //o------------------------------------------------------------------------------------------------o
-UI32 cHTMLTemplate::GetScheduledUpdate( void ) const
+TVAL cHTMLTemplate::GetScheduledUpdate( void ) const
 {
 	return scheduledUpdate;
 }
@@ -878,7 +878,7 @@ UI32 cHTMLTemplate::GetScheduledUpdate( void ) const
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets the Update timer
 //o------------------------------------------------------------------------------------------------o
-UI32 cHTMLTemplate::GetUpdateTimer( void ) const
+TVAL cHTMLTemplate::GetUpdateTimer( void ) const
 {
 	return updateTimer;
 }

--- a/source/cHTMLSystem.h
+++ b/source/cHTMLSystem.h
@@ -27,14 +27,14 @@ enum ETemplateType
 class cHTMLTemplate
 {
 private:
-	UI32			updateTimer;
+	TVAL			updateTimer;
 	std::string		inputFile;
 	bool			loaded;
 	ETemplateType	type;
 	std::string		content;
 	std::string		outputFile;
 	std::string		name;
-	UI32			scheduledUpdate;
+	TVAL			scheduledUpdate;
 
 public:
 	cHTMLTemplate();
@@ -50,8 +50,8 @@ public:
 	std::string		GetOutput( void ) const;
 	std::string		GetInput( void ) const;
 	ETemplateType	GetTemplateType( void ) const;
-	UI32			GetScheduledUpdate( void ) const;
-	UI32			GetUpdateTimer( void ) const;
+	TVAL			GetScheduledUpdate( void ) const;
+	TVAL			GetUpdateTimer( void ) const;
 };
 
 class cHTMLTemplates

--- a/source/cServerData.cpp
+++ b/source/cServerData.cpp
@@ -1446,7 +1446,7 @@ auto CServerData::MaxStaminaMovement( SI16 value ) -> void
 	maxStaminaMovement = value;
 }
 
-auto CServerData::BuildSystemTimeValue( cSD_TID timerId ) const ->TIMERVAL
+auto CServerData::BuildSystemTimeValue( cSD_TID timerId ) const -> TIMERVAL
 {
 	return BuildTimeValue( static_cast<R32>( SystemTimer( timerId )));
 }

--- a/source/cSocket.cpp
+++ b/source/cSocket.cpp
@@ -413,11 +413,11 @@ void CSocket::ForceOffline( bool newValue )
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets/Sets the time point at which the char times out
 //o------------------------------------------------------------------------------------------------o
-SI32 CSocket::IdleTimeout( void ) const
+TVAL CSocket::IdleTimeout( void ) const
 {
 	return idleTimeout;
 }
-void CSocket::IdleTimeout( SI32 newValue )
+void CSocket::IdleTimeout( TVAL newValue )
 {
 	idleTimeout = newValue;
 	wasIdleWarned = false;
@@ -471,11 +471,11 @@ void CSocket::SkillDelayMsgShown( bool value )
 //|	Purpose		-	Gets/Sets the time point at which the player gets kicked if assistant tool
 //|					has not responded to request to negotiate for features
 //o------------------------------------------------------------------------------------------------o
-SI32 CSocket::NegotiateTimeout( void ) const
+TVAL CSocket::NegotiateTimeout( void ) const
 {
 	return negotiateTimeout;
 }
-void CSocket::NegotiateTimeout( SI32 newValue )
+void CSocket::NegotiateTimeout( TVAL newValue )
 {
 	negotiateTimeout = newValue;
 }
@@ -1060,8 +1060,8 @@ SI32 CSocket::Receive( SI32 x, bool doLog )
 {
 	SI32 count			= 0;
 	UI08 recvAttempts	= 0;
-	UI32 curTime		= GetClock();
-	UI32 nexTime		= curTime;
+	TVAL curTime		= GetClock();
+	TVAL nexTime		= curTime;
 	do
 	{
 		count = static_cast<int>( recv( static_cast<UOXSOCKET>( cliSocket ), ( char * )&buffer[inlength], x - inlength, 0 ));

--- a/source/cSocket.h
+++ b/source/cSocket.h
@@ -79,11 +79,11 @@ private:
 	UI16			accountNum;
 
 	CChar *			currCharObj;
-	SI32			idleTimeout;
+	TVAL			idleTimeout;
 	bool			wasIdleWarned;
 	bool			objDelayMsgShown;
 	bool			skillDelayMsgShown;
-	SI32			negotiateTimeout;
+	TVAL			negotiateTimeout;
 	bool			negotiatedWithAssistant;
 
 	UI08			buffer[MAXBUFFER];
@@ -194,11 +194,11 @@ public:
 	PickupLocations	PickupSpot( void ) const;
 	SERIAL			PickupSerial( void ) const;
 	bool			FirstPacket( void ) const;
-	SI32			IdleTimeout( void ) const;
+	TVAL			IdleTimeout( void ) const;
 	bool			WasIdleWarned( void ) const;
 	bool			ObjDelayMsgShown( void ) const;
 	bool			SkillDelayMsgShown( void ) const;
-	SI32			NegotiateTimeout( void ) const;
+	TVAL			NegotiateTimeout( void ) const;
 	bool			NegotiatedWithAssistant( void ) const;
 	UI08 *			Buffer( void );
 	UI08 *			OutBuffer( void );
@@ -263,11 +263,11 @@ public:
 	void			PickupSpot( PickupLocations newValue );
 	void			PickupSerial( SERIAL pickupSerial );
 	void			FirstPacket( bool newValue );
-	void			IdleTimeout( SI32 newValue );
+	void			IdleTimeout( TVAL newValue );
 	void			WasIdleWarned( bool value );
 	void			ObjDelayMsgShown( bool value );
 	void			SkillDelayMsgShown( bool value );
-	void			NegotiateTimeout( SI32 newValue );
+	void			NegotiateTimeout( TVAL newValue );
 	void			NegotiatedWithAssistant( bool value );
 	void			WalkSequence( SI16 newValue );
 	void			AcctNo( UI16 newValue );

--- a/source/cWeather.cpp
+++ b/source/cWeather.cpp
@@ -2226,12 +2226,8 @@ bool cWeatherAb::doWeatherEffect( CSocket *mSock, CChar& mChar, WeatherType elem
 	if( !( weatherSys > weather.size() || weather.empty() ) && mChar.GetWeathDamage( element ) != 0 && mChar.GetWeathDamage( element ) <= cwmWorldState->GetUICurrentTime() )
 	{
 		const R32 tempCurrent	= Temp( weatherSys );
-		//const R32 tempMax		= MaxTemp( weatherSys );
-		//const R32 tempMin		= MinTemp( weatherSys );
-		//const R32 tempSnowMax	= SnowThreshold( weatherSys );
 		const R32 tempEffMax	= EffectiveMaxTemp( weatherSys );
 		const R32 tempEffMin	= EffectiveMinTemp( weatherSys );
-
 
 		R32 damageModifier		= 0;
 		SI32 damage				= 0;

--- a/source/cmdtable.cpp
+++ b/source/cmdtable.cpp
@@ -783,7 +783,7 @@ void Command_RegSpawn( CSocket *s )
 
 		if( oldstrutil::upper( Commands->CommandString( 2, 2 )) == "ALL" )
 		{
-			const UI32 s_t						= GetClock();
+			const TVAL s_t						= GetClock();
 			std::for_each( cwmWorldState->spawnRegions.begin(), cwmWorldState->spawnRegions.end(), [&itemsSpawned, &npcsSpawned]( std::pair<UI16, CSpawnRegion *> entry )
 			{
 				if( entry.second )
@@ -799,7 +799,7 @@ void Command_RegSpawn( CSocket *s )
 			{
 				s->SysMessage( 9022, cwmWorldState->spawnRegions.size() ); // Failed to spawn any new items or npcs in %u SpawnRegions
 			}
-			const UI32 e_t = GetClock();
+			const TVAL e_t = GetClock();
 			Console.Print( oldstrutil::format( "RegionSpawn cycle completed in %.02fsec\n", ( static_cast<R32>( e_t - s_t )) / 1000.0f ));
 		}
 		else

--- a/source/effect.cpp
+++ b/source/effect.cpp
@@ -619,7 +619,7 @@ auto cEffects::CheckTempeffects() -> void
 	CSocket *tSock = nullptr;
 	CBaseObject *myObj = nullptr;
 
-	const UI32 j = cwmWorldState->GetUICurrentTime();
+	const TVAL j = cwmWorldState->GetUICurrentTime();
 	std::vector<CTEffect*> removeEffects;
 	auto collection = cwmWorldState->tempEffects.collection();
 	for( auto &Effect : collection )
@@ -1206,7 +1206,7 @@ void ResumeEffect( CTEffect *Effect )
 	if( pauseTime > 0 )
 	{
 		// Effect IS paused, let's resume it and prolong the original timer by the amount of time it's been paused
-		const UI32 currTime = cwmWorldState->GetUICurrentTime();
+		const TVAL currTime = cwmWorldState->GetUICurrentTime();
 		auto expireTime = Effect->ExpireTime();
 		expireTime = expireTime + ( currTime - pauseTime );
 		Effect->ExpireTime( expireTime );
@@ -1801,7 +1801,7 @@ void cEffects::SaveEffects( void )
 {
 	std::ofstream effectDestination;
 	const char blockDiscriminator[] = "\n\n---EFFECT---\n\n";
-	SI32 s_t = GetClock();
+	TVAL s_t = GetClock();
 
 	Console << "Saving Effects...   ";
 	Console.TurnYellow();
@@ -1827,7 +1827,7 @@ void cEffects::SaveEffects( void )
 	Console << "\b\b\b\b";
 	Console.PrintDone();
 
-	SI32 e_t = GetClock();
+	TVAL e_t = GetClock();
 	Console.Print( oldstrutil::format("Effects saved in %.02fsec\n", ( static_cast<R32>( e_t-s_t )) / 1000.0f ));
 }
 

--- a/source/funcdecl.h
+++ b/source/funcdecl.h
@@ -145,7 +145,7 @@ inline TIMERVAL BuildTimeValue( R32 timeFromNow )
 	return static_cast<TIMERVAL>( cwmWorldState->GetUICurrentTime() + static_cast<TIMERVAL>( std::round(( static_cast<R32>( 1000 ) * timeFromNow ))));
 }
 
-UI32	GetClock( void );
+TVAL	GetClock( void );
 inline char *	RealTime( char *time_str )
 {
 	auto timet = std::chrono::system_clock::to_time_t( std::chrono::system_clock::now() );

--- a/source/regions.cpp
+++ b/source/regions.cpp
@@ -797,7 +797,7 @@ void CMapHandler::Save( void )
 	onePercent /= 100.0f;
 	const char blockDiscriminator[] = "\n\n---REGION---\n\n";
 	UI32 count						= 0;
-	const UI32 s_t						= GetClock();
+	const TVAL s_t						= GetClock();
 
 	Console << "Saving Character and Item Map Region data...   ";
 	Console.TurnYellow();
@@ -907,7 +907,7 @@ void CMapHandler::Save( void )
 	Console << "\b\b\b\b";
 	Console.PrintDone();
 
-	const UI32 e_t = GetClock();
+	const TVAL e_t = GetClock();
 	Console.Print( oldstrutil::format( "World saved in %.02fsec\n", ( static_cast<R32>( e_t - s_t )) / 1000.0f ));
 
 	i = 0;
@@ -944,7 +944,7 @@ void CMapHandler::Load( void )
 	std::ifstream readDestination;
 	Console.TurnYellow();
 	Console << "0%";
-	UI32 s_t				= GetClock();
+	TVAL s_t				= GetClock();
 	std::string basePath	= cwmWorldState->ServerData()->Directory( CSDDP_SHARED );
 	std::string filename;
 
@@ -1025,7 +1025,7 @@ void CMapHandler::Load( void )
 	ObjectFactory::GetSingleton().IterateOver( OT_CHAR, b, nullptr, &PostLoadFunctor );
 	houseDestination.close();
 
-	UI32 e_t	= GetClock();
+	TVAL e_t	= GetClock();
 	Console.Print( oldstrutil::format( "ASCII world loaded in %.02fsec\n", ( static_cast<R32>( e_t - s_t )) / 1000.0f ));
 
 	UI08 i		= 0;

--- a/source/regions.h
+++ b/source/regions.h
@@ -22,13 +22,13 @@ const SI16 UpperY = static_cast<SI16>( 4096 / MapRowSize );
 struct MapResource_st
 {
 	SI16	oreAmt;
-	UI32	oreTime;
+	TVAL	oreTime;
 	SI16	logAmt;
-	UI32	logTime;
+	TVAL	logTime;
 	SI16	fishAmt;
-	UI32	fishTime;
+	TVAL	fishTime;
 
-	MapResource_st( SI16 defOre = 0, SI16 defLog = 0, SI16 defFish = 0, UI32 defOreTime = 0, UI32 defLogTIme = 0, UI32 defFishTIme = 0 ) : 
+	MapResource_st( SI16 defOre = 0, SI16 defLog = 0, SI16 defFish = 0, TVAL defOreTime = 0, TVAL defLogTIme = 0, TVAL defFishTIme = 0 ) :
 		oreAmt( defOre ), oreTime( defOreTime ), logAmt( defLog ), logTime( defLogTIme ), fishAmt( defFish ), fishTime( defFishTIme )
 	{
 	}

--- a/source/skills.cpp
+++ b/source/skills.cpp
@@ -179,11 +179,11 @@ void CSkills::RegenerateOre( SI16 grX, SI16 grY, UI08 worldNum )
 	MapResource_st *orePart	= MapRegion->GetResource( grX, grY, worldNum );
 	SI16 oreCeiling			= cwmWorldState->ServerData()->ResOre();
 	UI16 oreTimer			= cwmWorldState->ServerData()->ResOreTime();
-	if( static_cast<UI32>( orePart->oreTime) <= cwmWorldState->GetUICurrentTime() )	// regenerate some more?
+	if( orePart->oreTime <= cwmWorldState->GetUICurrentTime() )	// regenerate some more?
 	{
 		for( SI16 counter = 0; counter < oreCeiling; ++counter )	// keep regenerating ore
 		{
-			if( orePart->oreAmt < oreCeiling && static_cast<UI32>( orePart->oreAmt + counter * oreTimer * 1000 ) < cwmWorldState->GetUICurrentTime() )
+			if( orePart->oreAmt < oreCeiling && static_cast<TVAL>( orePart->oreAmt + counter * oreTimer * 1000 ) < cwmWorldState->GetUICurrentTime() )
 			{
 				++orePart->oreAmt;
 			}
@@ -743,8 +743,6 @@ void CSkills::HandleSkillChange( CChar *c, UI08 sk, SI08 skillAdvance, bool succ
 
 	if( mSock == nullptr )
 		return;
-
-	//srand( GetClock() ); // Randomize
 
 	atrop[ALLSKILLS] = 0; // set the last of out copy array
 	for( counter = 0; counter < ALLSKILLS; ++counter )

--- a/source/speech.cpp
+++ b/source/speech.cpp
@@ -641,7 +641,7 @@ bool CSpeechQueue::InternalPoll( void )
 	{
 		toCheck = ( *slIter );
 
-		if( toCheck->At() == -1 || static_cast<UI32>( toCheck->At() ) <= cwmWorldState->GetUICurrentTime() )
+		if( toCheck->At() == -1 || toCheck->At() <= cwmWorldState->GetUICurrentTime() )
 		{
 			retVal = true;
 			SayIt(( *toCheck ));

--- a/source/speech.h
+++ b/source/speech.h
@@ -324,7 +324,7 @@ private:
 	SpeechTarget	targType;
 	FontType		targFont;
 	UnicodeTypes	targLanguage;
-	SI32			timeToSayAt;	// time when it should be said
+	TVAL			timeToSayAt;	// time when it should be said
 	std::string		toSay;
 	std::string		sName;
 	UI08			minCmdLevelToReceive;
@@ -348,7 +348,7 @@ public:
 	SpeechTarget		TargType( void ) const			{	return targType;				}
 	FontType			Font( void ) const				{	return targFont;				}
 	UnicodeTypes		Language( void ) const			{	return targLanguage;			}
-	SI32				At( void ) const				{	return timeToSayAt;				}
+	TVAL				At( void ) const				{	return timeToSayAt;				}
 	const std::string	Speech( void ) const			{	return toSay;					}
 	const std::string	SpeakerName( void ) const		{	return sName;					}
 	UI08				CmdLevel( void ) const			{	return minCmdLevelToReceive;	}
@@ -362,7 +362,7 @@ public:
 	void				TargType( SpeechTarget type )	{	targType = type;				}
 	void				Font( FontType type )			{	targFont = type;				}
 	void				Language( UnicodeTypes val )	{	targLanguage = val;				}
-	void				At( SI32 newTime )				{	timeToSayAt = newTime;			}
+	void				At( TVAL newTime )				{	timeToSayAt = newTime;			}
 	void				CmdLevel( UI08 nLevel )			{	minCmdLevelToReceive = nLevel;	}
 
 	void Speech( const std::string& said )

--- a/source/teffect.h
+++ b/source/teffect.h
@@ -6,7 +6,7 @@ class CTEffect
 private:
 	SERIAL			source;
 	SERIAL			dest;
-	UI32			expiretime;
+	TVAL			expiretime;
 	UI08			num;
 	UI16			more1;
 	UI16			more2;
@@ -14,7 +14,7 @@ private:
 	bool			dispellable;
 	CBaseObject *	objptr;
 	UI16			assocScript;
-	UI32			pauseTime;
+	TVAL			pauseTime;
 
 public:
 	CTEffect() : source( INVALIDSERIAL ), dest( INVALIDSERIAL ), expiretime( 0 ), pauseTime( 0 ), num( 0 ), more1( 0 ), more2( 0 ), more3( 0 ), dispellable( false ), objptr( nullptr ), assocScript( 0xFFFF )
@@ -24,8 +24,8 @@ public:
 	UI16	AssocScript( void ) const		{	return assocScript;		}
 	CBaseObject *ObjPtr( void ) const		{	return objptr;			}
 	bool	Dispellable( void ) const		{	return dispellable;		}
-	UI32	ExpireTime( void ) const		{	return expiretime;		}
-	UI32	PauseTime( void ) const			{	return pauseTime;		}
+	TVAL	ExpireTime( void ) const		{	return expiretime;		}
+	TVAL	PauseTime( void ) const			{	return pauseTime;		}
 	SERIAL	Source( void ) const			{	return source;			}
 	SERIAL	Destination( void ) const		{	return dest;			}
 	UI08	Number( void ) const			{	return num;				}
@@ -35,7 +35,7 @@ public:
 
 	void	Source( SERIAL value )			{	source = value;			}
 	void	Destination( SERIAL value )		{	dest = value;			}
-	void	ExpireTime( UI32 value )		{	expiretime = value;		}
+	void	ExpireTime( TVAL value )		{	expiretime = value;		}
 	void	Number( UI08 value )			{	num = value;			}
 	void	More1( UI16 value )				{	more1 = value;			}
 	void	More2( UI16 value )				{	more2 = value;			}
@@ -43,7 +43,7 @@ public:
 	void	Dispellable( bool value )		{	dispellable = value;	}
 	void	ObjPtr( CBaseObject *value )	{	objptr = value;			}
 	void	AssocScript( UI16 value )		{	assocScript = value;	}
-	void	PauseTime( UI32 value )			{	pauseTime = value;	}
+	void	PauseTime( TVAL value )			{	pauseTime = value;	}
 
 	bool	Save( std::ostream &effectDestination ) const; // saves the current effect
 };

--- a/source/typedefs.h
+++ b/source/typedefs.h
@@ -69,7 +69,8 @@ using COLOUR		= std::uint16_t;
 using SKILLVAL		= std::uint16_t;
 using WEATHID		= std::uint16_t;
 using GUILDID		= std::int16_t;
-using TIMERVAL		= std::uint32_t;
+using TIMERVAL		= std::uint64_t;
+using TVAL		= std::uint64_t; // Abstract it away once and for all
 
 #if defined(_WIN32)
 using UOXSOCKET = 	std::uint32_t;

--- a/source/uox3.cpp
+++ b/source/uox3.cpp
@@ -303,7 +303,6 @@ auto main( SI32 argc, char *argv[] ) ->int
 		StartMilliTimer( tempSecs, tempMilli );
 		
 		cwmWorldState->CheckTimers();
-		//stopwatch.output( "Delta for CheckTimers" );
 		cwmWorldState->SetUICurrentTime( GetClock() );
 		tempTime = CheckMilliTimer( tempSecs, tempMilli );
 		cwmWorldState->ServerProfile()->IncTimerTime( tempTime );
@@ -1141,7 +1140,7 @@ auto DismountCreature( CChar *s ) -> void
 auto EndMessage( [[maybe_unused]] SI32 x ) -> void
 {
 	x = 0; // Really, then why take a parameter?
-	const UI32 iGetClock = cwmWorldState->GetUICurrentTime();
+	const TVAL iGetClock = cwmWorldState->GetUICurrentTime();
 	if( cwmWorldState->GetEndTime() < iGetClock )
 	{
 		cwmWorldState->SetEndTime( iGetClock );
@@ -2556,8 +2555,8 @@ auto CWorldMain::CheckAutoTimers() -> void
 						Network->Disconnect( tSock );
 					}
 				}
-				else if((( static_cast<UI32>( tSock->IdleTimeout() + 300 * 1000 ) <= GetUICurrentTime() 
-					&& static_cast<UI32>( tSock->IdleTimeout() + 200 * 1000 ) >= GetUICurrentTime() ) || GetOverflow() ) && !tSock->WasIdleWarned() )
+				else if((( static_cast<TVAL>( tSock->IdleTimeout() + 300 * 1000 ) <= GetUICurrentTime()
+					&& static_cast<TVAL>( tSock->IdleTimeout() + 200 * 1000 ) >= GetUICurrentTime() ) || GetOverflow() ) && !tSock->WasIdleWarned() )
 				{
 					//is their idle time between 3 and 5 minutes, and they haven't been warned already?
 					CPIdleWarning warn( 0x07 );
@@ -2567,7 +2566,7 @@ auto CWorldMain::CheckAutoTimers() -> void
 
 				if( serverData->KickOnAssistantSilence() )
 				{
-					if( !tSock->NegotiatedWithAssistant() && tSock->NegotiateTimeout() != -1 && static_cast<UI32>( tSock->NegotiateTimeout() ) <= GetUICurrentTime() )
+					if( !tSock->NegotiatedWithAssistant() && tSock->NegotiateTimeout() != -1 && tSock->NegotiateTimeout() <= GetUICurrentTime() )
 					{
 						const CChar *tChar = tSock->CurrcharObj();
 						if( !ValidateObject( tChar ))
@@ -2642,14 +2641,14 @@ auto CWorldMain::CheckAutoTimers() -> void
 			{
 				if( wsSocket )
 				{
-					if( static_cast<UI32>( wsSocket->IdleTimeout() ) < GetUICurrentTime() )
+					if( wsSocket->IdleTimeout() < GetUICurrentTime() )
 					{
 						wsSocket->IdleTimeout( BuildTimeValue( 60.0F ));
 						wsSocket->WasIdleWarned( true );//don't give them the message if they only have 60s
 					}
 					if( cwmWorldState->ServerData()->KickOnAssistantSilence() )
 					{
-						if( !wsSocket->NegotiatedWithAssistant() && static_cast<UI32>( wsSocket->NegotiateTimeout() ) < GetUICurrentTime() )
+						if( !wsSocket->NegotiatedWithAssistant() && wsSocket->NegotiateTimeout() < GetUICurrentTime() )
 						{
 							wsSocket->NegotiateTimeout( BuildTimeValue( 60.0F ));
 						}
@@ -2682,7 +2681,7 @@ auto CWorldMain::CheckAutoTimers() -> void
 		UI32 maxItemsSpawned	= 0;
 		UI32 maxNpcsSpawned		= 0;
 		
-		const UI32 s_t = GetClock();
+		const TVAL s_t = GetClock();
 		for( auto &[regnum, spawnReg] : cwmWorldState->spawnRegions )
 		{
 			if( spawnReg )
@@ -2698,7 +2697,7 @@ auto CWorldMain::CheckAutoTimers() -> void
 				maxNpcsSpawned += static_cast<UI32>( spawnReg->GetMaxCharSpawn() );
 			}
 		}
-		const UI32 e_t = GetClock();
+		const TVAL e_t = GetClock();
 		Console.Print( oldstrutil::format( "Regionspawn cycle completed in %.02fsec\n", ( static_cast<R32>( e_t - s_t )) / 1000.0f ));
 
 		// Adaptive spawn region check timer. The closer spawn regions as a whole are to being at their defined max capacity,
@@ -2771,23 +2770,6 @@ auto CWorldMain::CheckAutoTimers() -> void
 #endif
 		}
 	}
-
-	/*time_t oldIPTime = GetOldIPTime();
-	if( !GetIPUpdated() )
-	{
-		SetIPUpdated( true );
-		time(&oldIPTime);
-		SetOldIPTime( static_cast<UI32>(oldIPTime) );
-	}
-	time_t newIPTime = GetNewIPTime();
-	time(&newIPTime);
-	SetNewIPTime( static_cast<UI32>(newIPTime) );
-
-	if( difftime( GetNewIPTime(), GetOldIPTime() ) >= 120 )
-	{
-		ServerData()->RefreshIPs();
-		SetIPUpdated( false );
-	}*/
 
 	//Time functions
 	if(( GetUOTickCount() <= GetUICurrentTime() ) || ( GetOverflow() ))
@@ -3488,10 +3470,10 @@ auto AdvanceObj( CChar *applyTo, UI16 advObj, bool multiUse ) -> void
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Return CPU time used, Emulates clock()
 //o------------------------------------------------------------------------------------------------o
-auto GetClock() -> UI32
+auto GetClock() -> TVAL
 {
 	auto now = std::chrono::system_clock::now();
-	return static_cast<UI32>( std::chrono::duration_cast<std::chrono::milliseconds>( now - current ).count() );
+	return static_cast<TVAL>( std::chrono::duration_cast<std::chrono::milliseconds>( now - current ).count() );
 }
 
 //o------------------------------------------------------------------------------------------------o

--- a/source/worldmain.cpp
+++ b/source/worldmain.cpp
@@ -187,11 +187,11 @@ void CWorldMain::SetLoaded( bool newVal )
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets/Sets current time
 //o------------------------------------------------------------------------------------------------o
-UI32 CWorldMain::GetUICurrentTime( void ) const
+TVAL CWorldMain::GetUICurrentTime( void ) const
 {
 	return uiCurrentTime;
 }
-void CWorldMain::SetUICurrentTime( UI32 newVal )
+void CWorldMain::SetUICurrentTime( TVAL newVal )
 {
 	uiCurrentTime = newVal;
 }
@@ -203,11 +203,11 @@ void CWorldMain::SetUICurrentTime( UI32 newVal )
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets/Sets UO Minutes
 //o------------------------------------------------------------------------------------------------o
-UI32 CWorldMain::GetUOTickCount( void ) const
+TVAL CWorldMain::GetUOTickCount( void ) const
 {
 	return uoTickCount;
 }
-void CWorldMain::SetUOTickCount( UI32 newVal )
+void CWorldMain::SetUOTickCount( TVAL newVal )
 {
 	uoTickCount = newVal;
 }
@@ -235,11 +235,11 @@ void CWorldMain::SetOverflow( bool newVal )
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets/Sets time when server started up
 //o------------------------------------------------------------------------------------------------o
-UI32 CWorldMain::GetStartTime( void ) const
+TVAL CWorldMain::GetStartTime( void ) const
 {
 	return startTime;
 }
-void CWorldMain::SetStartTime( UI32 newVal )
+void CWorldMain::SetStartTime( TVAL newVal )
 {
 	startTime = newVal;
 }
@@ -251,11 +251,11 @@ void CWorldMain::SetStartTime( UI32 newVal )
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets/Sets time when server will shutdown
 //o------------------------------------------------------------------------------------------------o
-UI32 CWorldMain::GetEndTime( void ) const
+TVAL CWorldMain::GetEndTime( void ) const
 {
 	return endTime;
 }
-void CWorldMain::SetEndTime( UI32 newVal )
+void CWorldMain::SetEndTime( TVAL newVal )
 {
 	endTime = newVal;
 }
@@ -267,11 +267,11 @@ void CWorldMain::SetEndTime( UI32 newVal )
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets/Sets end time
 //o------------------------------------------------------------------------------------------------o
-UI32 CWorldMain::GetLClock( void ) const
+TVAL CWorldMain::GetLClock( void ) const
 {
 	return lClock;
 }
-void CWorldMain::SetLClock( UI32 newVal )
+void CWorldMain::SetLClock( TVAL newVal )
 {
 	lClock = newVal;
 }
@@ -283,11 +283,11 @@ void CWorldMain::SetLClock( UI32 newVal )
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets/Sets time for next auto worldsave
 //o------------------------------------------------------------------------------------------------o
-UI32 CWorldMain::GetNewTime( void ) const
+TVAL CWorldMain::GetNewTime( void ) const
 {
 	return newTime;
 }
-void CWorldMain::SetNewTime( UI32 newVal )
+void CWorldMain::SetNewTime( TVAL newVal )
 {
 	newTime = newVal;
 }
@@ -299,11 +299,11 @@ void CWorldMain::SetNewTime( UI32 newVal )
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets/Sets time of last auto worldsave
 //o------------------------------------------------------------------------------------------------o
-UI32 CWorldMain::GetOldTime( void ) const
+TVAL CWorldMain::GetOldTime( void ) const
 {
 	return oldTime;
 }
-void CWorldMain::SetOldTime( UI32 newVal )
+void CWorldMain::SetOldTime( TVAL newVal )
 {
 	oldTime = newVal;
 }
@@ -411,11 +411,11 @@ void CWorldMain::CheckTimers( void )
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets/Sets time for next auto IP update
 //o------------------------------------------------------------------------------------------------o
-UI32 CWorldMain::GetNewIPTime( void ) const
+TVAL CWorldMain::GetNewIPTime( void ) const
 {
 	return newIPtime;
 }
-void CWorldMain::SetNewIPTime( UI32 newVal )
+void CWorldMain::SetNewIPTime( TVAL newVal )
 {
 	newIPtime = newVal;
 }
@@ -426,11 +426,11 @@ void CWorldMain::SetNewIPTime( UI32 newVal )
 //o------------------------------------------------------------------------------------------------o
 //|	Purpose		-	Gets/Sets time of last auto IP update
 //o------------------------------------------------------------------------------------------------o
-UI32 CWorldMain::GetOldIPTime( void ) const
+TVAL CWorldMain::GetOldIPTime( void ) const
 {
 	return oldIPtime;
 }
-void CWorldMain::SetOldIPTime( UI32 newVal )
+void CWorldMain::SetOldIPTime( TVAL newVal )
 {
 	oldIPtime = newVal;
 }

--- a/source/worldmain.h
+++ b/source/worldmain.h
@@ -103,18 +103,18 @@ private:
 	bool		hasLoaded;
 
 	// Time Functions
-	UI32		uoTickCount;
-	UI32		startTime, endTime, lClock;
+	TVAL		uoTickCount;
+	TVAL		startTime, endTime, lClock;
 	bool		overflow;
-	UI32		uiCurrentTime;
+	TVAL		uiCurrentTime;
 
 	// Worldsave
-	UI32		oldTime, newTime;
+	TVAL		oldTime, newTime;
 	bool		autoSaved;
 	SaveStatus	worldSaveProgress;
 
 	// IP Update
-	UI32		oldIPtime, newIPtime;
+	TVAL		oldIPtime, newIPtime;
 	bool		ipUpdated;
 
 	// Misc
@@ -165,34 +165,34 @@ public:
 	bool		GetLoaded( void ) const;
 
 	// Time Functions
-	void		SetUICurrentTime( UI32 newVal );
-	UI32		GetUICurrentTime( void ) const;
-	void		SetUOTickCount( UI32 newVal );
-	UI32		GetUOTickCount( void ) const;
+	void		SetUICurrentTime( TVAL newVal );
+	TVAL	GetUICurrentTime( void ) const;
+	void		SetUOTickCount( TVAL newVal );
+	TVAL	GetUOTickCount( void ) const;
 	void		SetOverflow( bool newVal );
 	bool		GetOverflow( void ) const;
-	void		SetStartTime( UI32 newVal );
-	UI32		GetStartTime( void ) const;
-	void		SetEndTime( UI32 newVal );
-	UI32		GetEndTime( void ) const;
-	void		SetLClock( UI32 newVal );
-	UI32		GetLClock( void ) const;
+	void		SetStartTime( TVAL newVal );
+	TVAL	GetStartTime( void ) const;
+	void		SetEndTime( TVAL newVal );
+	TVAL	GetEndTime( void ) const;
+	void		SetLClock( TVAL newVal );
+	TVAL	GetLClock( void ) const;
 
 	// Worldsave
-	void		SetNewTime( UI32 newVal );
-	UI32		GetNewTime( void ) const;
-	void		SetOldTime( UI32 newVal );
-	UI32		GetOldTime( void ) const;
+	void		SetNewTime( TVAL newVal );
+	TVAL	GetNewTime( void ) const;
+	void		SetOldTime( TVAL newVal );
+	TVAL	GetOldTime( void ) const;
 	void		SetAutoSaved( bool newVal );
 	bool		GetAutoSaved( void ) const;
 	void		SetWorldSaveProgress( SaveStatus newVal );
 	SaveStatus	GetWorldSaveProgress( void ) const;
 
 	// IP update
-	UI32		GetNewIPTime( void ) const;
-	void		SetNewIPTime( UI32 newVal );
-	UI32		GetOldIPTime( void ) const;
-	void		SetOldIPTime( UI32 newVal );
+	TVAL	GetNewIPTime( void ) const;
+	void		SetNewIPTime( TVAL newVal );
+	TVAL	GetOldIPTime( void ) const;
+	void		SetOldIPTime( TVAL newVal );
 	void		SetIPUpdated( bool newVal );
 	bool		GetIPUpdated( void ) const;
 


### PR DESCRIPTION
According to the C++ reference, chrono should support at least 45 bits of accuracy for milliseconds.

This gives a 1115 year wraparound.

Bump the types for the timer from the uint32_t to uint64_t and encapsulate behind a TVAL type definition.