### PR TITLE
Fix for custom gumptype and reduction of log spam

### DIFF
--- a/source/UOXJSMethods.cpp
+++ b/source/UOXJSMethods.cpp
@@ -4855,7 +4855,10 @@ JSBool CMisc_CustomTarget( JSContext *cx, uintN argc, jsval *vp )
 	mySock->scriptForCallBack = JSMapping->currentActive();
 	UI08 tNum = static_cast<UI08>( JSVAL_TO_INT( argv[0] ));
 
+#if defined UOX_DEBUG_MODE
 	Console.Warning( oldstrutil::format( "CustomTarget script ID: %d", mySock->scriptForCallBack->GetScriptID() ) );
+#endif
+
 	constexpr auto maxsize = 512; // Could become long (make sure it's nullptr )
 	std::string toSay;
 	if( argc >= 2 )

--- a/source/UOXJSPropertyFuncs.cpp
+++ b/source/UOXJSPropertyFuncs.cpp
@@ -108,10 +108,10 @@ UI16 getScriptID( JSContext *cx, jsid id, JSPrototypes section )
 		auto str = JSID_TO_STRING( id );
 		char* chars = JS_EncodeString( cx, str );
 		propID = GetPropByName( section, chars );
-		if( propID == 0xFFFF )
+		/*if( propID == 0xFFFF )
 		{
 			Console.Log( oldstrutil::format( "String property '%s' found on object type %d in script %d", chars, section, JSMapping->currentActive()->GetScriptID() ), "warning.log");
-		}
+		}*/
 		js_free( chars );
 	}
 	else if( JSID_IS_INT( id ) )

--- a/source/cItem.cpp
+++ b/source/cItem.cpp
@@ -1938,7 +1938,7 @@ bool CItem::DumpBody( std::ostream &outStream ) const
 	outStream << "MoreXYZ=0x" << GetTempVar( CITV_MOREX ) << ",0x" << GetTempVar( CITV_MOREY ) << ",0x" << GetTempVar( CITV_MOREZ ) << newLine;
 	outStream << "Glow=0x" << GetGlow() << newLine;
 	outStream << "GlowBC=0x" << GetGlowColour() << newLine;
-	outStream << "GumpType=0x" << std::hex << GetGumpType() << std::dec << "," << GetPackXMin() << "," << GetPackXMax() << "," << GetPackYMin() << "," << GetPackYMax() << "," << GetPackZ() << newLine;
+	outStream << "GumpType=0x" << std::hex << GetGumpType() << std::dec << "," << GetPackXMin() << "," << GetPackXMax() << "," << GetPackYMin() << "," << GetPackYMax() << "," << static_cast<SI16>( GetPackZ() ) << std::hex << newLine;
 	outStream << "Ammo=0x" << GetAmmoId() << ",0x" << GetAmmoHue() << newLine;
 	outStream << "AmmoFX=0x" << GetAmmoFX() << ",0x" << GetAmmoFXHue() << ",0x" << GetAmmoFXRender() << newLine;
 	outStream << "Spells=0x" << GetSpell( 0 ) << ",0x" << GetSpell( 1 ) << ",0x" << GetSpell( 2 ) << newLine;


### PR DESCRIPTION
- [FIX] Fixed an issue with how custom gump type properties were saved to worldfiles, which would lead to a crash on next world load
- [UPD] Disabled logging of unknown JS object properties for now, as log message would also trigger for usage of JS object methods
- [UPD] Wrapped CustomTarget console warning in a debug define so it doesn't spam console/log file in release mode