### PR TITLE
Fix for 'IVL' language code error

### DIFF
--- a/source/speech.cpp
+++ b/source/speech.cpp
@@ -174,6 +174,14 @@ UnicodeTypes FindLanguage( CSocket *s, UI16 offset )
 	langCode[3] = 0;
 
 	std::string ulangCode = langCode;
+	
+	// Handle special case language code sometimes sent by some clients
+	if( ulangCode == "IVL" )
+	{
+		// Default to treat it as English
+		return UT_ENG;
+	}
+
 	ulangCode = oldstrutil::upper( ulangCode );
 
 	UnicodeTypes cLang = s->Language();

--- a/source/speech.cpp
+++ b/source/speech.cpp
@@ -179,7 +179,7 @@ UnicodeTypes FindLanguage( CSocket *s, UI16 offset )
 	if( ulangCode == "IVL" )
 	{
 		// Default to treat it as English
-		return UT_ENG;
+		return UT_ENU;
 	}
 
 	ulangCode = oldstrutil::upper( ulangCode );


### PR DESCRIPTION
- [FIX] Fixed an error that appears when client sends 'IVL' as an invalid language code. Now defaults to English language for such clients