### PR TITLE
Harden SpiderMonkey bindings and add JavaScript tests

### DIFF
--- a/data/js/commands/testjsbindings.js
+++ b/data/js/commands/testjsbindings.js
@@ -1,0 +1,661 @@
+/// <reference path="../definitions.d.ts" />
+// @ts-check
+
+function CommandRegistration()
+{
+	RegisterCommand( "testjsbindings", 2, true );
+	RegisterCommand( "testjsobjects", 2, true );
+	RegisterCommand( "testjsitem", 2, true );
+	RegisterCommand( "testjscontainer", 2, true );
+	RegisterCommand( "testjsextended", 2, true );
+	RegisterCommand( "testjsgc", 8, true );
+	RegisterCommand( "testjstimer", 8, true );
+	RegisterCommand( "testjsarguments", 2, true );
+	RegisterCommand( "testjserror", 2, true );
+	RegisterCommand( "testjsall", 2, true );
+}
+
+var gcTimerTestState = null;
+var gcTimerTestId = 32760;
+
+/** @type { ( socket: Socket, cmdString: string ) => void } */
+function command_TESTJSALL( socket, cmdString )
+{
+	command_TESTJSBINDINGS( socket, cmdString );
+	command_TESTJSOBJECTS( socket, cmdString );
+	command_TESTJSEXTENDED( socket, cmdString );
+	socket.SysMessage( "Non-targeted tests finished. Run testjsitem and testjscontainer for targeted tests." );
+}
+
+/** @type { ( socket: Socket, cmdString: string ) => void } */
+function command_TESTJSBINDINGS( socket, cmdString )
+{
+	var failures = [];
+
+	TestGlobal( failures, "Console", Console, [
+		"Print", "Log", "Error", "Warning", "PrintSectionBegin",
+		"TurnYellow", "TurnRed", "TurnGreen", "TurnBlue", "TurnNormal",
+		"TurnBrightWhite", "PrintDone", "PrintFailed", "PrintPassed",
+		"ClearScreen", "PrintBasedOnVal", "MoveTo", "PrintSpecial",
+		"BeginRestart", "BeginShutdown", "Reload"
+	]);
+	TestGlobal( failures, "Accounts", Accounts, [
+		"AddAccount", "DelAccount"
+	]);
+	TestGlobal( failures, "Timer", Timer, [] );
+	TestGlobal( failures, "Skills", Skills, [] );
+	TestGlobal( failures, "Spells", Spells, [] );
+	TestGlobal( failures, "CreateEntries", CreateEntries, [] );
+	TestGlobal( failures, "SCRIPT", SCRIPT, [] );
+	TestConstructor( failures, "Gump", Gump );
+	TestConstructor( failures, "Packet", Packet );
+	TestConstructor( failures, "UOXCFile", UOXCFile );
+
+	ReportBindingResults( socket, failures, "global JavaScript binding checks", "All global JavaScript binding checks passed." );
+}
+
+/** @type { ( socket: Socket, cmdString: string ) => void } */
+function command_TESTJSOBJECTS( socket, cmdString )
+{
+	var failures = [];
+	var pUser = socket.currentChar;
+
+	RunBindingTest( failures, "Socket.currentChar", function()
+	{
+		RequireBinding( ValidateObject( pUser ), "did not return a valid character" );
+	});
+	RunBindingTest( failures, "Socket properties", function()
+	{
+		RequireType( socket.account, "object", "Socket.account" );
+		RequireType( socket.bytesSent, "number", "Socket.bytesSent" );
+		RequireType( socket.bytesReceived, "number", "Socket.bytesReceived" );
+	});
+	RunBindingTest( failures, "Socket.SysMessage", function()
+	{
+		socket.SysMessage( "Socket.SysMessage binding passed." );
+	});
+	RunBindingTest( failures, "Socket methods", function()
+	{
+		TestMethods( failures, "Socket", socket, [
+			"SysMessage", "Disconnect", "SoundEffect", "CustomTarget", "PopUpTarget",
+			"GetByte", "GetWord", "GetDWord", "GetSByte", "GetSWord", "GetSDWord",
+			"GetString", "SetByte", "SetWord", "SetDWord", "SetString", "ReadBytes",
+			"OpenContainer", "OpenGump", "CloseGump", "OpenURL", "BuyFrom", "SellTo",
+			"WhoList", "Music", "GetTimer", "SetTimer", "SendAddMenu", "Page",
+			"MakeMenu", "Send", "CanSee", "DisplayDamage", "FirstTriggerWord",
+			"NextTriggerWord", "FinishedTriggerWords"
+		]);
+	});
+	RunBindingTest( failures, "Character properties", function()
+	{
+		RequireType( pUser.name, "string", "Character.name" );
+		RequireType( pUser.serial, "number", "Character.serial" );
+		RequireType( pUser.x, "number", "Character.x" );
+		RequireType( pUser.y, "number", "Character.y" );
+		RequireType( pUser.z, "number", "Character.z" );
+		RequireType( pUser.worldnumber, "number", "Character.worldnumber" );
+	});
+	RunBindingTest( failures, "Character tag methods", function()
+	{
+		pUser.GetTag( "__binding_test_missing__" );
+		pUser.GetTempTag( "__binding_test_missing__" );
+		RequireType( pUser.GetNumTags(), "number", "Character.GetNumTags()" );
+	});
+	RunBindingTest( failures, "Character methods", function()
+	{
+		TestMethods( failures, "Character", pUser, [
+			"KillTimers", "GetJSTimer", "SetJSTimer", "KillJSTimer", "TextMessage",
+			"YellMessage", "WhisperMessage", "EmoteMessage", "Delete", "DoAction",
+			"StaticEffect", "Teleport", "SetLocation", "SoundEffect", "GetTag",
+			"SetTag", "GetTempTag", "SetTempTag", "GetNumTags", "GetTagMap",
+			"GetTempTagMap", "DirectionTo", "TurnToward", "ResourceCount",
+			"UseResource", "CustomTarget", "PopUpTarget", "InRange", "FindItemLayer",
+			"StartTimer", "CheckSkill", "CastSpell", "SysMessage", "GetSerial",
+			"UpdateStats", "DistanceTo"
+		]);
+	});
+	RunBindingTest( failures, "Skills[0]", function()
+	{
+		var skill = Skills[0];
+		RequireType( skill, "object", "Skills[0]" );
+		RequireType( skill.name, "string", "Skills[0].name" );
+		RequireType( skill.scriptID, "number", "Skills[0].scriptID" );
+	});
+	RunBindingTest( failures, "Spells[1]", function()
+	{
+		var spell = Spells[1];
+		RequireType( spell, "object", "Spells[1]" );
+		RequireType( spell.id, "number", "Spells[1].id" );
+		RequireType( spell.name, "string", "Spells[1].name" );
+		RequireType( spell.enabled, "boolean", "Spells[1].enabled" );
+	});
+	RunBindingTest( failures, "Timer constants", function()
+	{
+		RequireType( Timer.TIMEOUT, "number", "Timer.TIMEOUT" );
+		RequireType( Timer.SPELLTIME, "number", "Timer.SPELLTIME" );
+	});
+	RunBindingTest( failures, "Console.Print", function()
+	{
+		Console.Print( "Console.Print live binding passed.\n" );
+	});
+
+	ReportBindingResults( socket, failures, "live JavaScript object tests", "All live JavaScript object tests passed." );
+}
+
+/** @type { ( socket: Socket, cmdString: string ) => void } */
+function command_TESTJSEXTENDED( socket, cmdString )
+{
+	var failures = [];
+	var pUser = socket.currentChar;
+
+	RunBindingTest( failures, "Account properties", function()
+	{
+		var account = socket.account;
+		RequireType( account, "object", "Socket.account" );
+		RequireType( account.id, "number", "Account.id" );
+		RequireType( account.username, "string", "Account.username" );
+		RequireType( account.flags, "number", "Account.flags" );
+		RequireType( account.totalPlayTime, "number", "Account.totalPlayTime" );
+		RequireType( account.isOnline, "boolean", "Account.isOnline" );
+		RequireType( account.isGM, "boolean", "Account.isGM" );
+	});
+	RunBindingTest( failures, "Region bindings", function()
+	{
+		var region = pUser.region;
+		RequireType( region, "object", "Character.region" );
+		RequireType( region.id, "number", "Region.id" );
+		RequireType( region.name, "string", "Region.name" );
+		RequireType( region.isGuarded, "boolean", "Region.isGuarded" );
+		RequireType( region.canMark, "boolean", "Region.canMark" );
+		RequireType( region.canRecall, "boolean", "Region.canRecall" );
+		RequireType( region.canGate, "boolean", "Region.canGate" );
+		TestMethods( failures, "Region", region, [
+			"AddScriptTrigger", "RemoveScriptTrigger", "GetOrePref", "GetOreChance"
+		]);
+	});
+	RunBindingTest( failures, "Optional Guild bindings", function()
+	{
+		if( pUser.guild != null )
+		{
+			RequireType( pUser.guild.name, "string", "Guild.name" );
+			RequireType( pUser.guild.id, "number", "Guild.id" );
+			RequireType( pUser.guild.numMembers, "number", "Guild.numMembers" );
+			TestMethods( failures, "Guild", pUser.guild, [
+				"AcceptRecruit", "IsAtPeace", "AddMember", "AddRecruit", "RemoveRecruit",
+				"RemoveMember", "RecruitToMember", "IsAtWar", "IsAlly", "IsNeutral"
+			]);
+		}
+	});
+	RunBindingTest( failures, "Optional Party bindings", function()
+	{
+		if( pUser.party != null )
+		{
+			RequireType( pUser.party.memberCount, "number", "Party.memberCount" );
+			RequireType( pUser.party.isNPC, "boolean", "Party.isNPC" );
+			TestMethods( failures, "Party", pUser.party, [ "GetMember", "Add", "Remove" ] );
+		}
+	});
+	RunBindingTest( failures, "Gump constructor", function()
+	{
+		var gump = new Gump();
+		TestMethods( failures, "Gump", gump, [
+			"Free", "AddBackground", "AddButton", "AddButtonTileArt", "AddPageButton",
+			"AddCheckbox", "AddCheckerTrans", "AddCroppedText", "AddGroup", "EndGroup",
+			"AddGump", "AddGumpColor", "AddHTMLGump", "AddPage", "AddPicture",
+			"AddPictureColor", "AddPicInPic", "AddItemProperty", "AddRadio", "AddText",
+			"AddTextEntry", "AddTextEntryLimited", "AddTiledGump", "AddToolTip",
+			"AddXMFHTMLGump", "AddXMFHTMLGumpColor", "AddXMFHTMLTok", "MasterGump",
+			"NoClose", "NoDispose", "NoMove", "NoResize", "Send"
+		]);
+		gump.Free();
+	});
+	RunBindingTest( failures, "Packet constructor", function()
+	{
+		var packet = new Packet();
+		TestMethods( failures, "Packet", packet, [
+			"Free", "WriteByte", "WriteShort", "WriteLong", "WriteString", "ReserveSize"
+		]);
+		packet.Free();
+	});
+	RunBindingTest( failures, "UOXCFile constructor", function()
+	{
+		var file = new UOXCFile();
+		TestMethods( failures, "UOXCFile", file, [
+			"Free", "Open", "Close", "Write", "Read", "ReadUntil", "EOF", "Length", "Pos"
+		]);
+		file.Free();
+	});
+
+	ReportBindingResults( socket, failures, "extended JavaScript binding tests", "All extended JavaScript binding tests passed." );
+}
+
+/** @type { ( socket: Socket, cmdString: string ) => void } */
+function command_TESTJSGC( socket, cmdString )
+{
+	var failures = [];
+	var pUser = socket.currentChar;
+	var account = socket.account;
+	var region = pUser.region;
+	var characterSerial = pUser.serial;
+	var accountId = account.id;
+	var regionId = region.id;
+	var retainedValues = [];
+
+	RunBindingTest( failures, "GC setup", function()
+	{
+		RequireBinding( ValidateObject( pUser ), "Socket.currentChar was invalid before collection" );
+		RequireType( account, "object", "Socket.account" );
+		RequireType( region, "object", "Character.region" );
+	});
+
+	for( var cycle = 0; cycle < 3; cycle++ )
+	{
+		RunBindingTest( failures, "GC allocation cycle " + ( cycle + 1 ), function()
+		{
+			var temporaryValues = [];
+			for( var i = 0; i < 10000; i++ )
+			{
+				temporaryValues.push({
+					index: i,
+					text: "JavaScript garbage collection test value " + i,
+					values: [i, i + 1, i + 2]
+				});
+			}
+			retainedValues.push( temporaryValues[cycle * 1000] );
+		});
+
+		RunBindingTest( failures, "Forced GC cycle " + ( cycle + 1 ), function()
+		{
+			pUser.ExecuteCommand( "gcollect" );
+			RequireBinding( ValidateObject( pUser ), "retained character became invalid" );
+			RequireBinding( pUser.serial == characterSerial, "retained character serial changed" );
+			RequireBinding( socket.currentChar === pUser, "character wrapper identity changed" );
+			RequireBinding( socket.account === account, "account wrapper identity changed" );
+			RequireBinding( account.id == accountId, "retained account ID changed" );
+			RequireBinding( pUser.region === region, "region wrapper identity changed" );
+			RequireBinding( region.id == regionId, "retained region ID changed" );
+			RequireType( retainedValues[cycle].text, "string", "Retained JavaScript value" );
+		});
+	}
+
+	ReportBindingResults( socket, failures, "JavaScript garbage-collection tests", "All JavaScript garbage-collection tests passed." );
+}
+
+/** @type { ( socket: Socket, cmdString: string ) => void } */
+function command_TESTJSTIMER( socket, cmdString )
+{
+	var pUser = socket.currentChar;
+
+	gcTimerTestState = {
+		socket: socket,
+		character: pUser,
+		account: socket.account,
+		region: pUser.region,
+		characterSerial: pUser.serial,
+		accountId: socket.account.id,
+		regionId: pUser.region.id,
+		value: "retained timer test value"
+	};
+
+	pUser.StartTimer( 1000, gcTimerTestId, true );
+	pUser.ExecuteCommand( "gcollect" );
+	socket.SysMessage( "JavaScript timer/rooting test started. Results will follow in one second." );
+}
+
+/** @type { ( timerObj: Character | Item, timerID: number ) => void } */
+function onTimer( timerObj, timerID )
+{
+	if( timerID != gcTimerTestId )
+	{
+		return;
+	}
+
+	var failures = [];
+	var state = gcTimerTestState;
+
+	RunBindingTest( failures, "Retained timer state", function()
+	{
+		RequireType( state, "object", "Timer test state" );
+		RequireBinding( ValidateObject( timerObj ), "timer callback object was invalid" );
+		RequireBinding( timerObj === state.character, "character wrapper identity changed across callback" );
+		RequireBinding( timerObj.serial == state.characterSerial, "character serial changed across callback" );
+		RequireBinding( state.socket.currentChar === state.character, "socket character wrapper identity changed" );
+		RequireBinding( state.socket.account === state.account, "account wrapper identity changed across callback" );
+		RequireBinding( state.account.id == state.accountId, "account ID changed across callback" );
+		RequireBinding( state.character.region === state.region, "region wrapper identity changed across callback" );
+		RequireBinding( state.region.id == state.regionId, "region ID changed across callback" );
+		RequireBinding( state.value == "retained timer test value", "retained JavaScript value changed" );
+	});
+
+	if( state != null && state.socket != null )
+	{
+		ReportBindingResults( state.socket, failures, "JavaScript timer/rooting tests", "All JavaScript timer/rooting tests passed." );
+	}
+	gcTimerTestState = null;
+}
+
+/** @type { ( socket: Socket, cmdString: string ) => void } */
+function command_TESTJSARGUMENTS( socket, cmdString )
+{
+	var failures = [];
+	var pUser = socket.currentChar;
+
+	ExpectBindingError( failures, "RandomNumber missing argument", function()
+	{
+		RandomNumber( 1 );
+	});
+	ExpectBindingError( failures, "GetDictionaryEntry missing argument", function()
+	{
+		GetDictionaryEntry();
+	});
+	ExpectBindingError( failures, "CalcCharFromSer missing argument", function()
+	{
+		CalcCharFromSer();
+	});
+	ExpectBindingError( failures, "CalcItemFromSer missing argument", function()
+	{
+		CalcItemFromSer();
+	});
+	ExpectBindingError( failures, "DistanceBetween null object", function()
+	{
+		DistanceBetween( null, pUser );
+	});
+	ExpectBindingError( failures, "DistanceBetween wrong wrapper", function()
+	{
+		DistanceBetween({}, pUser );
+	});
+	ExpectBindingError( failures, "DoTempEffect wrong target wrapper", function()
+	{
+		DoTempEffect( 0, null, {}, 0, 0, 0, 0 );
+	});
+	ExpectBindingError( failures, "MakeItem wrong wrappers", function()
+	{
+		MakeItem({}, {}, 0 );
+	});
+	ExpectBindingError( failures, "Character.GetTag missing argument", function()
+	{
+		pUser.GetTag();
+	});
+	ExpectBindingError( failures, "Character.GetTempTag extra argument", function()
+	{
+		pUser.GetTempTag( "__binding_test_missing__", "extra" );
+	});
+	ExpectBindingError( failures, "Character.GetTagMap extra argument", function()
+	{
+		pUser.GetTagMap( true );
+	});
+	ExpectBindingError( failures, "Character.GetTempTagMap extra argument", function()
+	{
+		pUser.GetTempTagMap( true );
+	});
+	ExpectBindingError( failures, "Character.DistanceTo wrong wrapper", function()
+	{
+		pUser.DistanceTo({});
+	});
+	ExpectBindingError( failures, "Character.InRange wrong wrapper", function()
+	{
+		pUser.InRange({}, 1 );
+	});
+	ExpectBindingError( failures, "Character.DirectionTo wrong wrapper", function()
+	{
+		pUser.DirectionTo({});
+	});
+	ExpectBindingError( failures, "Character.TurnToward wrong wrapper", function()
+	{
+		pUser.TurnToward({});
+	});
+	ExpectBindingError( failures, "Socket.OpenContainer wrong wrapper", function()
+	{
+		socket.OpenContainer({});
+	});
+	ExpectBindingError( failures, "Socket.Send wrong wrapper", function()
+	{
+		socket.Send({});
+	});
+
+	ReportBindingResults( socket, failures, "JavaScript argument-validation tests", "All JavaScript argument-validation tests passed." );
+}
+
+/** @type { ( socket: Socket, cmdString: string ) => void } */
+function command_TESTJSERROR( socket, cmdString )
+{
+	socket.SysMessage( "An intentional JavaScript error will follow. This is expected." );
+	BindingErrorLevelOne();
+}
+
+function BindingErrorLevelOne()
+{
+	BindingErrorLevelTwo();
+}
+
+function BindingErrorLevelTwo()
+{
+	throw new Error( "Intentional JavaScript binding error-reporting test" );
+}
+
+/** @type { ( socket: Socket, cmdString: string ) => void } */
+function command_TESTJSITEM( socket, cmdString )
+{
+	socket.CustomTarget( 0, "Select an item to test its JavaScript bindings." );
+}
+
+/** @type { ( socket: Socket, target: Character | Item | null ) => void } */
+function onCallback0( socket, target )
+{
+	if( !ValidateObject( target ) || !target.isItem )
+	{
+		socket.SysMessage( "You must select a valid item." );
+		return;
+	}
+
+	var failures = [];
+
+	RunBindingTest( failures, "Item identity properties", function()
+	{
+		RequireType( target.name, "string", "Item.name" );
+		RequireType( target.serial, "number", "Item.serial" );
+		RequireType( target.id, "number", "Item.id" );
+		RequireType( target.colour, "number", "Item.colour" );
+		RequireType( target.isItem, "boolean", "Item.isItem" );
+	});
+	RunBindingTest( failures, "Item location properties", function()
+	{
+		RequireType( target.x, "number", "Item.x" );
+		RequireType( target.y, "number", "Item.y" );
+		RequireType( target.z, "number", "Item.z" );
+		RequireType( target.worldnumber, "number", "Item.worldnumber" );
+		RequireType( target.instanceID, "number", "Item.instanceID" );
+	});
+	RunBindingTest( failures, "Item value properties", function()
+	{
+		RequireType( target.amount, "number", "Item.amount" );
+		RequireType( target.type, "number", "Item.type" );
+		RequireType( target.weight, "number", "Item.weight" );
+		RequireType( target.movable, "number", "Item.movable" );
+	});
+	RunBindingTest( failures, "Item methods", function()
+	{
+		RequireType( target.GetTag, "function", "Item.GetTag" );
+		RequireType( target.GetTempTag, "function", "Item.GetTempTag" );
+		RequireType( target.GetNumTags, "function", "Item.GetNumTags" );
+		RequireType( target.GetTileName, "function", "Item.GetTileName" );
+		RequireType( target.IsMulti, "function", "Item.IsMulti" );
+	});
+	RunBindingTest( failures, "Item method calls", function()
+	{
+		target.GetTag( "__binding_test_missing__" );
+		target.GetTempTag( "__binding_test_missing__" );
+		RequireType( target.GetNumTags(), "number", "Item.GetNumTags()" );
+		RequireType( target.GetTileName(), "string", "Item.GetTileName()" );
+		RequireType( target.IsMulti(), "boolean", "Item.IsMulti()" );
+	});
+
+	ReportBindingResults( socket, failures, "live JavaScript item tests", "All live JavaScript item tests passed." );
+}
+
+/** @type { ( socket: Socket, cmdString: string ) => void } */
+function command_TESTJSCONTAINER( socket, cmdString )
+{
+	socket.CustomTarget( 1, "Select a container to test its JavaScript iterator bindings." );
+}
+
+/** @type { ( socket: Socket, target: Character | Item | null ) => void } */
+function onCallback1( socket, target )
+{
+	if( !ValidateObject( target ) || !target.isItem || !target.isContType )
+	{
+		socket.SysMessage( "You must select a valid container." );
+		return;
+	}
+
+	var failures = [];
+	var itemCount = 0;
+	var maximumIterations = 10000;
+
+	RunBindingTest( failures, "Container properties", function()
+	{
+		RequireType( target.itemsinside, "number", "Item.itemsinside" );
+		RequireType( target.totalItemCount, "number", "Item.totalItemCount" );
+		RequireType( target.maxItems, "number", "Item.maxItems" );
+		RequireType( target.weight, "number", "Item.weight" );
+		RequireType( target.weightMax, "number", "Item.weightMax" );
+	});
+	RunBindingTest( failures, "Container iterator methods", function()
+	{
+		RequireType( target.FirstItem, "function", "Item.FirstItem" );
+		RequireType( target.NextItem, "function", "Item.NextItem" );
+		RequireType( target.FinishedItems, "function", "Item.FinishedItems" );
+	});
+	RunBindingTest( failures, "Container iteration", function()
+	{
+		for( var item = target.FirstItem(); !target.FinishedItems(); item = target.NextItem() )
+		{
+			if( itemCount >= maximumIterations )
+			{
+				throw new Error( "iterator exceeded the safety limit" );
+			}
+			if( !ValidateObject( item ) || !item.isItem )
+			{
+				throw new Error( "iterator returned an invalid item" );
+			}
+			RequireType( item.serial, "number", "Contained Item.serial" );
+			RequireType( item.name, "string", "Contained Item.name" );
+			itemCount++;
+		}
+	});
+	RunBindingTest( failures, "Container item count", function()
+	{
+		if( itemCount != target.itemsinside )
+		{
+			throw new Error( "iterator found " + itemCount + " items, but itemsinside reported " + target.itemsinside );
+		}
+	});
+
+	ReportBindingResults(
+		socket,
+		failures,
+		"live JavaScript container tests",
+		"All live JavaScript container tests passed. Items found: " + itemCount + "."
+	);
+}
+
+function TestGlobal( failures, globalName, globalObject, expectedMethods )
+{
+	if( typeof globalObject != "object" || globalObject == null )
+	{
+		failures.push( globalName + " is unavailable." );
+		return;
+	}
+
+	for( var i = 0; i < expectedMethods.length; i++ )
+	{
+		var methodName = expectedMethods[i];
+		if( typeof globalObject[methodName] != "function" )
+		{
+			failures.push( globalName + "." + methodName + " is not a function." );
+		}
+	}
+}
+
+function TestConstructor( failures, constructorName, constructorValue )
+{
+	if( typeof constructorValue != "function" )
+	{
+		failures.push( constructorName + " is not a constructor." );
+	}
+}
+
+function TestMethods( failures, objectName, objectToTest, expectedMethods )
+{
+	for( var i = 0; i < expectedMethods.length; i++ )
+	{
+		var methodName = expectedMethods[i];
+		if( typeof objectToTest[methodName] != "function" )
+		{
+			failures.push( objectName + "." + methodName + " is not a function." );
+		}
+	}
+}
+
+function RunBindingTest( failures, testName, testFunction )
+{
+	try
+	{
+		testFunction();
+	}
+	catch( error )
+	{
+		failures.push( testName + ": " + error.message );
+	}
+}
+
+function ExpectBindingError( failures, testName, testFunction )
+{
+	var errorWasThrown = false;
+
+	try
+	{
+		testFunction();
+	}
+	catch( error )
+	{
+		errorWasThrown = true;
+		RequireType( error.message, "string", testName + " error message" );
+	}
+
+	if( !errorWasThrown )
+	{
+		failures.push( testName + ": expected a JavaScript exception" );
+	}
+}
+
+function RequireType( value, expectedType, valueName )
+{
+	RequireBinding(
+		typeof value == expectedType && value != null,
+		valueName + " expected " + expectedType + ", received " + typeof value
+	);
+}
+
+function RequireBinding( condition, message )
+{
+	if( !condition )
+	{
+		throw new Error( message );
+	}
+}
+
+function ReportBindingResults( socket, failures, testName, successMessage )
+{
+	if( failures.length == 0 )
+	{
+		socket.SysMessage( successMessage );
+		return;
+	}
+
+	socket.SysMessage( failures.length + " " + testName + " failed:" );
+	for( var i = 0; i < failures.length; i++ )
+	{
+		socket.SysMessage( failures[i] );
+	}
+}

--- a/data/js/jse_fileassociations.scp
+++ b/data/js/jse_fileassociations.scp
@@ -511,6 +511,7 @@
 1068=commands/spawnregionadmin.js
 1069=commands/em.js
 1070=commands/champion_spawn_cmd.js
+1071=commands/testjsbindings.js
 }
 
 //-------------------------------------------

--- a/source/CJSEngine.cpp
+++ b/source/CJSEngine.cpp
@@ -187,11 +187,12 @@ CJSRuntime::CJSRuntime( UI32 engineSize )
 
 	JS::InitSelfHostedCode(jsContext);
 
-	jsGlobal = JS_NewGlobalObject(jsContext, &global_class, nullptr, JS::FireOnNewGlobalHook, options);
-	if( jsGlobal == nullptr )
+	JS::RootedObject rootedGlobal( jsContext, JS_NewGlobalObject( jsContext, &global_class, nullptr, JS::FireOnNewGlobalHook, options ));
+	if( rootedGlobal == nullptr )
 	{
 		Shutdown( FATAL_UOX3_JAVASCRIPT );
 	}
+	jsGlobal.init( jsContext, rootedGlobal );
 	realmGuard = new JSAutoRealm( jsContext, jsGlobal );
 	JS::InitRealmStandardClasses( jsContext );
 
@@ -203,10 +204,9 @@ CJSRuntime::~CJSRuntime( void )
 {
 	Cleanup();
 
-	// TODO: Unroot them
-
 	delete realmGuard;
 	realmGuard = nullptr;
+	jsGlobal.reset();
 	JS_DestroyContext( jsContext );
 }
 
@@ -333,7 +333,8 @@ void CJSRuntime::InitializePrototypes()
   (*protoList)[JSP_CREATEENTRIES] .set( rootClass(          cx, obj, &UOXCreateEntries_class, nullptr,  nullptr,                nullptr ) );
   (*protoList)[JSP_TIMER]         .set( rootClass(          cx, obj, &UOXTimer_class,         nullptr,  CTimerProperties,       nullptr ) );
   (*protoList)[JSP_SOCK]          .set( rootClass(          cx, obj, &UOXSocket_class,        nullptr,  CSocketProps,           CSocket_Methods ) );
-  (*protoList)[JSP_ACCOUNTS]      .set( rootClass(          cx, obj, &UOXAccount_class,       nullptr,  CAccountProperties,     CAccount_Methods ) );
+  (*protoList)[JSP_ACCOUNT]       .set( rootClass(          cx, obj, &UOXAccount_class,       nullptr,  CAccountProperties,     nullptr ) );
+  (*protoList)[JSP_ACCOUNTS]      .set( rootClass(          cx, obj, &UOXAccount_class,       nullptr,  nullptr,                CAccount_Methods ) );
   (*protoList)[JSP_CONSOLE]       .set( rootClass(          cx, obj, &UOXConsole_class,       nullptr,  CConsoleProperties,     CConsole_Methods ) );
   (*protoList)[JSP_REGION]        .set( rootClass(          cx, obj, &UOXRegion_class,        nullptr,  CRegionProperties,      CRegion_Methods ) );
   (*protoList)[JSP_SPAWNREGION]   .set( rootClass(          cx, obj, &UOXSpawnRegion_class,   nullptr,  CSpawnRegionProperties, nullptr ) );
@@ -345,13 +346,13 @@ void CJSRuntime::InitializePrototypes()
   (*protoList)[JSP_GUMP]          .set( rootClass(          cx, obj, &UOXGump_class,          Gump,     nullptr,                nullptr ) );
   (*protoList)[JSP_FILE]          .set( rootClass(          cx, obj, &UOXFile_class,          UOXCFile, nullptr,                nullptr ) );
   (*protoList)[JSP_SCRIPT]        .set( rootClass(          cx, obj, &uox_class,              nullptr,  CScriptProperties,      nullptr ) );
-  spellsObj        = defineSingleton( cx, obj, "Spells",        &UOXSpells_class,       ( *protoList )[JSP_SPELLS] );
-  skillsObj        = defineSingleton( cx, obj, "Skills",        &UOXGlobalSkills_class, ( *protoList )[JSP_GLOBALSKILLS] );
-  accountsObj      = defineSingleton( cx, obj, "Accounts",      &UOXAccount_class,      ( *protoList )[JSP_ACCOUNTS] );
-  consoleObj       = defineSingleton( cx, obj, "Console",       &UOXConsole_class,      ( *protoList )[JSP_CONSOLE] );
-  createEntriesObj = defineSingleton( cx, obj, "CreateEntries", &UOXCreateEntries_class, ( *protoList )[JSP_CREATEENTRIES] );
-  timerObj         = defineSingleton( cx, obj, "Timer",         &UOXTimer_class,        ( *protoList )[JSP_TIMER] );
-  scriptObj        = defineSingleton( cx, obj, "SCRIPT",        &uox_class,             ( *protoList )[JSP_SCRIPT] );
+  JS::RootedObject spellsObj(        cx, defineSingleton( cx, obj, "Spells",        &UOXSpells_class,        ( *protoList )[JSP_SPELLS] ) );
+  JS::RootedObject skillsObj(        cx, defineSingleton( cx, obj, "Skills",        &UOXGlobalSkills_class,  ( *protoList )[JSP_GLOBALSKILLS] ) );
+  JS::RootedObject accountsObj(      cx, defineSingleton( cx, obj, "Accounts",      &UOXAccount_class,       ( *protoList )[JSP_ACCOUNTS] ) );
+  JS::RootedObject consoleObj(       cx, defineSingleton( cx, obj, "Console",       &UOXConsole_class,       ( *protoList )[JSP_CONSOLE] ) );
+  JS::RootedObject createEntriesObj( cx, defineSingleton( cx, obj, "CreateEntries", &UOXCreateEntries_class, ( *protoList )[JSP_CREATEENTRIES] ) );
+  JS::RootedObject timerObj(         cx, defineSingleton( cx, obj, "Timer",         &UOXTimer_class,         ( *protoList )[JSP_TIMER] ) );
+  JS::RootedObject scriptObj(        cx, defineSingleton( cx, obj, "SCRIPT",        &uox_class,              ( *protoList )[JSP_SCRIPT] ) );
   // clang-format on
 
 	JS::RootedObject skillsCollection( cx, skillsObj );
@@ -369,7 +370,6 @@ void CJSRuntime::InitializePrototypes()
 			JSPROP_ENUMERATE | JSPROP_READONLY | JSPROP_PERMANENT );
 	}
 
-	// TODO: Root them
 }
 
 JSRuntime *CJSRuntime::GetRuntime( void ) const

--- a/source/CJSEngine.h
+++ b/source/CJSEngine.h
@@ -58,16 +58,9 @@ private:
 	std::array<JSOBJECTMAP, IUE_COUNT>					objectList;
     JS::RootedObjectVector *   protoList;
 
-	JSObject * spellsObj;
-	JSObject * skillsObj;
-	JSObject * accountsObj;
-	JSObject * consoleObj;
-	JSObject * createEntriesObj;
-	JSObject * timerObj;
-	JSObject * scriptObj;
 	JSRuntime * jsRuntime;
 	JSContext * jsContext;
-	JSObject * jsGlobal;
+	JS::PersistentRootedObject jsGlobal;
 	JSAutoRealm * realmGuard;
 
 	JSObject *	FindAssociatedObject( IUEEntries iType, void *index );

--- a/source/SEFunctions.cpp
+++ b/source/SEFunctions.cpp
@@ -175,8 +175,7 @@ bool SE_DoTempEffect( JSContext *cx, unsigned int argc, JS::Value *vp )
 
 	if( iType == 0 )	// character
 	{
-		JSObject *mydestc = &args.get(2).toObject();
-  CChar *mydestChar = JS::GetMaybePtrFromReservedSlot<CChar>( mydestc , 0 );
+		CChar *mydestChar = GetWrappedObject<CChar>( args.get( 2 ), &UOXChar_class );
 
 		if( !ValidateObject( mydestChar ))
 		{
@@ -194,8 +193,7 @@ bool SE_DoTempEffect( JSContext *cx, unsigned int argc, JS::Value *vp )
 	}
 	else
 	{
-		JSObject *mydesti = &args.get(2).toObject();
-  CItem  *mydestItem = JS::GetMaybePtrFromReservedSlot<CItem >( mydesti , 0 );
+		CItem *mydestItem = GetWrappedObject<CItem>( args.get( 2 ), &UOXItem_class );
 
 		if( !ValidateObject( mydestItem ))
 		{
@@ -643,10 +641,13 @@ bool SE_MakeItem( JSContext *cx, unsigned int argc, JS::Value *vp )
 		ScriptError( cx, "MakeItem: Invalid number of arguments (takes 3, or 4 - socket, character, createID - and optionally - resourceColour)" );
 		return false;
 	}
-	JSObject *mSock = &args.get(0).toObject();
-  CSocket  *sock = JS::GetMaybePtrFromReservedSlot<CSocket >( mSock , 0 );
-	JSObject *mChar = &args.get(1).toObject();
-  CChar  *player = JS::GetMaybePtrFromReservedSlot<CChar >( mChar , 0 );
+	CSocket *sock = GetWrappedObject<CSocket>( args.get( 0 ), &UOXSocket_class );
+	CChar *player = GetWrappedObject<CChar>( args.get( 1 ), &UOXChar_class );
+	if( sock == nullptr )
+	{
+		ScriptError( cx, "MakeItem: Invalid socket" );
+		return false;
+	}
 	if( !ValidateObject( player ))
 	{
 		ScriptError( cx, "MakeItem: Invalid character" );
@@ -734,7 +735,7 @@ bool SE_CommandExists( JSContext *cx, unsigned int argc, JS::Value *vp )
 bool SE_FirstCommand( JSContext *cx, unsigned int argc, JS::Value *vp )
 {
 	const std::string tVal = Commands->FirstCommand();
-	JSString *strSpeech = nullptr;
+	JS::RootedString strSpeech( cx );
 	if( tVal.empty() )
 	{
 		strSpeech = JS_NewStringCopyZ( cx, "" );
@@ -756,7 +757,7 @@ bool SE_FirstCommand( JSContext *cx, unsigned int argc, JS::Value *vp )
 bool SE_NextCommand( JSContext *cx, unsigned int argc, JS::Value *vp )
 {
 	const std::string tVal = Commands->NextCommand();
-	JSString *strSpeech = nullptr;
+	JS::RootedString strSpeech( cx );
 	if( tVal.empty() )
 	{
 		strSpeech = JS_NewStringCopyZ( cx, "" );
@@ -1727,8 +1728,7 @@ bool SE_FindMulti( JSContext *cx, unsigned int argc, JS::Value *vp )
 	UI16 instanceId = 0;
 	if( argc == 1 )
 	{
-		JSObject *myitemptr = &args.get(0).toObject();
-  CBaseObject  *myItemPtr = JS::GetMaybePtrFromReservedSlot<CBaseObject >( myitemptr , 0 );
+		CBaseObject *myItemPtr = GetBaseObject( args.get( 0 ));
 		if( ValidateObject( myItemPtr ))
 		{
 			xLoc		= myItemPtr->GetX();
@@ -2278,8 +2278,7 @@ bool SE_GetPackOwner( JSContext *cx, unsigned int argc, JS::Value *vp )
 
 	if( mType == 0 )	// item
 	{
-		JSObject *mItem	= &args.get(0).toObject();
-  CItem  *myItem = JS::GetMaybePtrFromReservedSlot<CItem >( mItem , 0 );
+		CItem *myItem = GetWrappedObject<CItem>( args.get( 0 ), &UOXItem_class );
 		pOwner			= FindItemOwner( myItem );
 	}
 	else				// serial
@@ -2319,8 +2318,7 @@ bool SE_FindRootContainer( JSContext *cx, unsigned int argc, JS::Value *vp )
 
 	if( mType == 0 )	// item
 	{
-		JSObject *mItem	= &args.get(0).toObject();
-  CItem  *myItem = JS::GetMaybePtrFromReservedSlot<CItem >( mItem , 0 );
+		CItem *myItem = GetWrappedObject<CItem>( args.get( 0 ), &UOXItem_class );
 		iRoot			= FindRootContainer( myItem );
 	}
 	else				// serial
@@ -2355,8 +2353,7 @@ bool SE_CalcTargetedItem( JSContext *cx, unsigned int argc, JS::Value *vp )
 		return false;
 	}
 
-	JSObject *mysockptr = &args.get(0).toObject();
-  CSocket  *sChar	 = JS::GetMaybePtrFromReservedSlot<CSocket >( mysockptr , 0 );
+	CSocket *sChar = GetWrappedObject<CSocket>( args.get( 0 ), &UOXSocket_class );
 	if( sChar == nullptr )
 	{
 		ScriptError( cx, "CalcTargetedItem: Invalid socket" );
@@ -2391,8 +2388,7 @@ bool SE_CalcTargetedChar( JSContext *cx, unsigned int argc, JS::Value *vp )
 		return false;
 	}
 
-	JSObject *mysockptr = &args.get(0).toObject();
-  CSocket  *sChar	 = JS::GetMaybePtrFromReservedSlot<CSocket >( mysockptr , 0 );
+	CSocket *sChar = GetWrappedObject<CSocket>( args.get( 0 ), &UOXSocket_class );
 	if( sChar == nullptr )
 	{
 		ScriptError( cx, "CalcTargetedChar: Invalid socket" );
@@ -2640,8 +2636,7 @@ bool SE_AreaCharacterFunction( JSContext *cx, unsigned int argc, JS::Value *vp )
 		return false;
 	}
 
-	JSObject *srcBaseObj = &args.get(1).toObject();
-  CBaseObject  *srcObject = JS::GetMaybePtrFromReservedSlot<CBaseObject >( srcBaseObj , 0 );
+	CBaseObject *srcObject = GetBaseObject( args.get( 1 ));
 
 	if( !ValidateObject( srcObject ))
 	{
@@ -2728,8 +2723,7 @@ bool SE_AreaItemFunction( JSContext *cx, unsigned int argc, JS::Value *vp )
 		return false;
 	}
 
-	JSObject *srcBaseObj = &args.get(1).toObject();
-  CBaseObject  *srcObject = JS::GetMaybePtrFromReservedSlot<CBaseObject >( srcBaseObj , 0 );
+	CBaseObject *srcObject = GetBaseObject( args.get( 1 ));
 
 	if( !ValidateObject( srcObject ))
 	{
@@ -2807,8 +2801,7 @@ bool SE_GetDictionaryEntry( JSContext *cx, unsigned int argc, JS::Value *vp )
 	std::string txt = Dictionary->GetEntry( dictEntry, language );
 	txt = oldstrutil::stringToWstringToString( txt );
 
-	JSString *strTxt = nullptr;
-	strTxt = JS_NewStringCopyZ( cx, txt.c_str() );
+	JS::RootedString strTxt( cx, JS_NewStringCopyZ( cx, txt.c_str() ));
 	args.rval().setString( strTxt );
 	return true;
 }
@@ -2829,8 +2822,12 @@ bool SE_Yell( JSContext *cx, unsigned int argc, JS::Value *vp )
 		return false;
 	}
 
-	JSObject *mSock			= &args.get(0).toObject();
-  CSocket  *mySock		 = JS::GetMaybePtrFromReservedSlot<CSocket >( mSock , 0 );
+	CSocket *mySock = GetWrappedObject<CSocket>( args.get( 0 ), &UOXSocket_class );
+	if( mySock == nullptr )
+	{
+		ScriptError( cx, "Yell: Invalid socket" );
+		return false;
+	}
 	CChar *myChar			= mySock->CurrcharObj();
 	std::string textToYell	= JS_GetStringBytes( cx, args.get(1));
 	UI08 commandLevel		= static_cast<UI08>( args.get(2).toInt32());
@@ -3005,8 +3002,7 @@ bool SE_SendStaticStats( JSContext *cx, unsigned int argc, JS::Value *vp )
 		return false;
 	}
 
-	JSObject *mSock			= &args.get(0).toObject();
-  CSocket  *mySock		 = JS::GetMaybePtrFromReservedSlot<CSocket >( mSock , 0 );
+	CSocket *mySock = GetWrappedObject<CSocket>( args.get( 0 ), &UOXSocket_class );
 	if( mySock == nullptr )
 	{
 		ScriptError( cx, "SendStaticStats: passed an invalid socket!" );
@@ -3124,13 +3120,10 @@ bool SE_IterateOver( JSContext *cx, unsigned int argc, JS::Value *vp )
 								// If there's a 2nd argument, see if it's a Socket
 	if( argc == 2 && args.get(1).isObject() )
 	{
-		JSObject* sockObj = &args.get(1).toObject();
-		if( sockObj )
+		CSocket *pSock = GetWrappedObject<CSocket>( args.get( 1 ), &UOXSocket_class );
+		if( pSock != nullptr )
 		{
-			// Our CSocket pointer is stored in the JS private data for that object
-  CSocket * pSock = JS::GetMaybePtrFromReservedSlot<CSocket>( sockObj , 0 );
-			if( pSock )
-				iterData->socket = pSock;
+			iterData->socket = pSock;
 		}
 	}
 
@@ -3178,14 +3171,10 @@ bool SE_IterateOverSpawnRegions( JSContext *cx, unsigned int argc, JS::Value *vp
 	// Check if a socket was passed as an argument in JS
 	if( argc >= 1 && args.get(0).isObject() )
 	{
-		JSObject* sockObj = &args.get(0).toObject();
-		if( sockObj )
+		CSocket *pSock = GetWrappedObject<CSocket>( args.get( 0 ), &UOXSocket_class );
+		if( pSock != nullptr )
 		{
-  CSocket * pSock = JS::GetMaybePtrFromReservedSlot<CSocket>( sockObj , 0 );
-			if( pSock )
-			{
-				iterData->socket = pSock;
-			}
+			iterData->socket = pSock;
 		}
 	}
 
@@ -4516,7 +4505,7 @@ bool SE_GetServerSetting( JSContext *cx, unsigned int argc, JS::Value *vp )
 		return false;
 	}
 
-	JSString *tString;
+	JS::RootedString tString( cx );
 	std::string settingName = oldstrutil::upper( JS_GetStringBytes( cx, args.get(0)));
 	if( !settingName.empty() )
 	{
@@ -4626,7 +4615,7 @@ bool SE_GetServerSetting( JSContext *cx, unsigned int argc, JS::Value *vp )
 				break;
 			case 40:	 // DIRECTORY
 			{
-				JSString *tString = JS_NewStringCopyZ( cx, cwmWorldState->ServerData()->Directory( CSDDP_ROOT ).c_str() );
+				JS::RootedString tString( cx, JS_NewStringCopyZ( cx, cwmWorldState->ServerData()->Directory( CSDDP_ROOT ).c_str() ));
 				args.rval().setString( tString );
 				break;
 			}
@@ -5910,7 +5899,7 @@ bool SE_GetCharacterCount( JSContext *cx, unsigned int argc, JS::Value *vp )
 bool SE_GetServerVersionString( JSContext *cx, unsigned int argc, JS::Value *vp )
 {
 	std::string versionString = CVersionClass::GetVersion() + "." + CVersionClass::GetBuild() + " [" + OS_STR + "]";
-	JSString *tString = JS_NewStringCopyZ( cx, versionString.c_str() );
+	JS::RootedString tString( cx, JS_NewStringCopyZ( cx, versionString.c_str() ));
 	auto args = JS::CallArgsFromVp(argc, vp);
 	args.rval().setString( tString );
 	return true;
@@ -5933,11 +5922,14 @@ bool SE_DistanceBetween( JSContext *cx, unsigned int argc, JS::Value *vp )
 	if( argc <= 3 )
 	{
 		// 2 or 3 arguments - find dinstance between two objects in 2D or 3D
-		JSObject *srcObj = &args.get(0).toObject();
-		JSObject *trgObj = &args.get(1).toObject();
+		if( !args.get( 0 ).isObject() || !args.get( 1 ).isObject() )
+		{
+			ScriptError( cx, "DistanceBetween: Invalid source or target object" );
+			return false;
+		}
 		bool checkZ = argc == 3 ? ( args.get(2).toBoolean() == true ) : false;
-    CBaseObject  *srcBaseObj = JS::GetMaybePtrFromReservedSlot<CBaseObject >( srcObj , 0 );
-    CBaseObject  *trgBaseObj = JS::GetMaybePtrFromReservedSlot<CBaseObject >( trgObj , 0 );
+		CBaseObject *srcBaseObj = GetBaseObject( args.get( 0 ));
+		CBaseObject *trgBaseObj = GetBaseObject( args.get( 1 ));
 		if( !ValidateObject( srcBaseObj ) || !ValidateObject( trgBaseObj ))
 		{
 			ScriptError( cx, "DistanceBetween: Invalid source or target object" );

--- a/source/UOXJSMethods.cpp
+++ b/source/UOXJSMethods.cpp
@@ -475,19 +475,18 @@ bool CSocket_Send( JSContext *cx, unsigned argc, JS::Value* vp )
 	if( argc != 1 )
 	{
 		ScriptError( cx, "(CSocket_Send) Invalid Number of Arguments %d, needs: 1 ", argc );
-		return true;
+		return false;
 	}
 
 	auto args = JS::CallArgsFromVp(argc, vp);
 	auto obj = getThis( cx, args );
   CSocket *mSock		 = JS::GetMaybePtrFromReservedSlot<CSocket>( obj, 0 );
-	JSObject *jsObj			= &args.get(0).toObject();
-	CPUOXBuffer* myPacket = JS::GetMaybePtrFromReservedSlot<CPUOXBuffer>(jsObj, 0);
+	CPUOXBuffer *myPacket = GetWrappedObject<CPUOXBuffer>( args.get( 0 ), &UOXPacket_class );
 
 	if( mSock == nullptr || myPacket == nullptr )
 	{
 		ScriptError( cx, "(CPacket_WriteString) Invalid Object Passed" );
-		return true;
+		return false;
 	}
 
 	mSock->Send( myPacket );
@@ -1500,8 +1499,7 @@ bool CGump_AddItemProperty( JSContext *cx, unsigned argc, JS::Value* vp )
 	}
 
 	auto args = JS::CallArgsFromVp(argc, vp);
-	JSObject *tObj = &args.get(0).toObject();
-  CBaseObject  *trgObj = JS::GetMaybePtrFromReservedSlot<CBaseObject >( tObj, 0 );
+	CBaseObject *trgObj = GetBaseObject( args.get( 0 ));
 
 	if( !ValidateObject( trgObj ) || ( trgObj->GetSerial() == INVALIDSERIAL ))
 	{
@@ -2711,8 +2709,7 @@ bool CChar_Follow( JSContext *cx, unsigned argc, JS::Value* vp )
 		return true;
 	}
 
-	JSObject *jsObj = &args.get(0).toObject();
-	CBaseObject *myObj = JS::GetMaybePtrFromReservedSlot<CBaseObject>( jsObj, 0 );
+	CBaseObject *myObj = GetBaseObject( args.get( 0 ));
 
 	if( !ValidateObject( myObj ) || myObj->GetSerial() >= BASEITEMSERIAL )
 	{
@@ -3596,6 +3593,7 @@ bool CBase_GetTag( JSContext *cx, unsigned argc, JS::Value* vp )
 	if( argc != 1 )
 	{
 		ScriptError( cx, "GetTag: Invalid Count of Parameters: %d, need: 1", argc );
+		return false;
 	}
 
 	auto args = JS::CallArgsFromVp(argc, vp);
@@ -3612,7 +3610,7 @@ bool CBase_GetTag( JSContext *cx, unsigned argc, JS::Value* vp )
 	TAGMAPOBJECT localObject	= myObj->GetTag( localString );
 	if( localObject.m_ObjectType == TAGMAP_TYPE_STRING )
 	{
-		JSString *localJSString = JS_NewStringCopyN( cx, ( const char* )localObject.m_StringValue.c_str(), localObject.m_StringValue.length() );
+		JS::RootedString localJSString( cx, JS_NewStringCopyN( cx, ( const char* )localObject.m_StringValue.c_str(), localObject.m_StringValue.length() ));
 		args.rval().setString( localJSString );
 	}
 	else if( localObject.m_ObjectType == TAGMAP_TYPE_BOOL )
@@ -3639,6 +3637,7 @@ bool CBase_SetTag( JSContext *cx, unsigned argc, JS::Value* vp )
 	if(( argc != 2 ) && ( argc != 1 ))
 	{
 		ScriptError( cx, "SetTag: Invalid Count of Parameters: %d, need: 2", argc );
+		return false;
 	}
 
 	auto args = JS::CallArgsFromVp(argc, vp);
@@ -3741,6 +3740,7 @@ bool CBase_GetTempTag( JSContext *cx, unsigned argc, JS::Value* vp )
 	if( argc != 1 )
 	{
 		ScriptError( cx, "GetTempTag: Invalid Count of Parameters: %d, need: 1", argc );
+		return false;
 	}
 
 	auto args = JS::CallArgsFromVp(argc, vp);
@@ -3757,7 +3757,7 @@ bool CBase_GetTempTag( JSContext *cx, unsigned argc, JS::Value* vp )
 	TAGMAPOBJECT localObject	= myObj->GetTempTag( localString );
 	if( localObject.m_ObjectType == TAGMAP_TYPE_STRING )
 	{
-		JSString *localJSString = JS_NewStringCopyN( cx, ( const char* )localObject.m_StringValue.c_str(), localObject.m_StringValue.length() );
+		JS::RootedString localJSString( cx, JS_NewStringCopyN( cx, ( const char* )localObject.m_StringValue.c_str(), localObject.m_StringValue.length() ));
 		args.rval().setString( localJSString );
 	}
 	else if( localObject.m_ObjectType == TAGMAP_TYPE_BOOL )
@@ -3785,6 +3785,7 @@ bool CBase_SetTempTag( JSContext *cx, unsigned argc, JS::Value* vp )
 	if(( argc != 2 ) && ( argc != 1 ))
 	{
 		ScriptError( cx, "SetTempTag: Invalid Count of Parameters: %d, need: 2", argc );
+		return false;
 	}
 
 	auto args = JS::CallArgsFromVp(argc, vp);
@@ -3887,6 +3888,7 @@ bool CBase_GetNumTags( JSContext *cx, unsigned argc, JS::Value* vp )
 	if( argc != 0 )
 	{
 		ScriptError( cx, "Invalid Count of Parameters: %d, need: 0", argc );
+		return false;
 	}
 
 	auto args = JS::CallArgsFromVp(argc, vp);
@@ -3914,6 +3916,7 @@ bool CBase_GetTagMap( JSContext *cx, unsigned argc, JS::Value* vp )
 	if( argc != 0 )
 	{
 		ScriptError( cx, "Invalid Count of Parameters: %d, need: 0", argc );
+		return false;
 	}
 
 	auto args = JS::CallArgsFromVp(argc, vp);
@@ -3958,7 +3961,7 @@ bool CBase_GetTagMap( JSContext *cx, unsigned argc, JS::Value* vp )
 			case TAGMAP_TYPE_STRING:
 			{
 				jsType = JS::Int32Value( TAGMAP_TYPE_STRING );
-				JSString *jsStringVal = JS_NewStringCopyZ( cx, tagObj.second.m_StringValue.c_str() );
+				JS::RootedString jsStringVal( cx, JS_NewStringCopyZ( cx, tagObj.second.m_StringValue.c_str() ));
 				jsValue = JS::StringValue( jsStringVal );
 				break;
 			}
@@ -3998,6 +4001,7 @@ bool CBase_GetTempTagMap( JSContext *cx, unsigned argc, JS::Value* vp )
 	if( argc != 0 )
 	{
 		ScriptError( cx, "Invalid Count of Parameters: %d, need: 0", argc );
+		return false;
 	}
 
 	auto args = JS::CallArgsFromVp(argc, vp);
@@ -4042,7 +4046,7 @@ bool CBase_GetTempTagMap( JSContext *cx, unsigned argc, JS::Value* vp )
 			case TAGMAP_TYPE_STRING:
 			{
 				jsType = JS::Int32Value( TAGMAP_TYPE_STRING );
-				JSString *jsStringVal = JS_NewStringCopyZ( cx, tagObj.second.m_StringValue.c_str() );
+				JS::RootedString jsStringVal( cx, JS_NewStringCopyZ( cx, tagObj.second.m_StringValue.c_str() ));
 				jsValue = JS::StringValue( jsStringVal );
 				break;
 			}
@@ -4101,7 +4105,7 @@ bool CChar_OpenBank( JSContext *cx, unsigned argc, JS::Value* vp )
 	// Open it to the passed socket
 	else if( argc == 1 )
 	{
-		mySock = JS::GetMaybePtrFromReservedSlot<CSocket>( &args.get(0).toObject(), 0 );
+		mySock = GetWrappedObject<CSocket>( args.get( 0 ), &UOXSocket_class );
 		if( mySock != nullptr )
 		{
 			mySock->OpenBank( myChar );
@@ -4139,11 +4143,13 @@ bool CSocket_OpenContainer( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-	CItem *contToOpen = JS::GetMaybePtrFromReservedSlot<CItem>( &args.get(0).toObject(), 0 );
-	if( ValidateObject( contToOpen ))
+	CItem *contToOpen = GetWrappedObject<CItem>( args.get( 0 ), &UOXItem_class );
+	if( !ValidateObject( contToOpen ))
 	{
-		mSock->OpenPack( contToOpen, false );
+		ScriptError( cx, "OpenContainer: Invalid container" );
+		return false;
 	}
+	mSock->OpenPack( contToOpen, false );
 
 	return true;
 }
@@ -4170,7 +4176,7 @@ bool CChar_OpenLayer( JSContext *cx, unsigned argc, JS::Value* vp )
 		ScriptError( cx, "OpenLayer, Invalid count of Paramters: %d", argc );
 		return false;
 	}
-	CSocket *mySock = JS::GetMaybePtrFromReservedSlot<CSocket>( &args.get(0).toObject(), 0 );
+	CSocket *mySock = GetWrappedObject<CSocket>( args.get( 0 ), &UOXSocket_class );
 	if( mySock != nullptr )
 	{
 		CItem *iLayer = myChar->GetItemAtLayer( static_cast<ItemLayers>( args.get(1).toInt32()));
@@ -4212,7 +4218,7 @@ bool CChar_TurnToward( JSContext *cx, unsigned argc, JS::Value* vp )
 			return false;
 		}
 
-		CBaseObject *myObj = JS::GetMaybePtrFromReservedSlot<CBaseObject>( &args.get(0).toObject(), 0 );
+		CBaseObject *myObj = GetBaseObject( args.get( 0 ));
 		if( !ValidateObject( myObj ))
 		{
 			ScriptError( cx, "(TurnToward) Invalid Object passed" );
@@ -4288,7 +4294,12 @@ bool CChar_DirectionTo( JSContext *cx, unsigned argc, JS::Value* vp )
 			return false;
 		}
 
-  auto *myObj = JS::GetMaybePtrFromReservedSlot<CBaseObject>( &args.get(0).toObject(), 0 );
+		auto *myObj = GetBaseObject( args.get( 0 ));
+		if( !ValidateObject( myObj ))
+		{
+			ScriptError( cx, "(DirectionTo) Invalid Object passed" );
+			return false;
+		}
 
 		x = myObj->GetX();
 		y = myObj->GetY();
@@ -4371,7 +4382,7 @@ bool CGuild_AcceptRecruit( JSContext *cx, unsigned argc, JS::Value* vp )
 	}
 	else if( argc == 1 )
 	{
-		auto *myChar = JS::GetMaybePtrFromReservedSlot<CChar>( &args.get(0).toObject(), 0 );
+		auto *myChar = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 		myGuild->RecruitToMember( *myChar );
 	}
 	else
@@ -4645,8 +4656,7 @@ bool CGuild_IsAtWar( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-	JSObject* otherObj = &args.get(0).toObject();
-  auto * otherGuild = JS::GetMaybePtrFromReservedSlot<CGuild>( otherObj , 0 );
+	auto *otherGuild = GetWrappedObject<CGuild>( args.get( 0 ), &UOXGuild_class );
 	if( otherGuild == nullptr )
 	{
 		ScriptError( cx, "IsAtWar: Invalid target Guild object" );
@@ -4688,8 +4698,7 @@ bool CGuild_IsAlly( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-	JSObject* otherObj = &args.get(0).toObject();
-  auto * otherGuild = JS::GetMaybePtrFromReservedSlot<CGuild>( otherObj , 0 );
+	auto *otherGuild = GetWrappedObject<CGuild>( args.get( 0 ), &UOXGuild_class );
 	if( otherGuild == nullptr )
 	{
 		ScriptError( cx, "IsAlly: Invalid target Guild object" );
@@ -4731,8 +4740,7 @@ bool CGuild_IsNeutral( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-	JSObject* otherObj = &args.get(0).toObject();
-  auto * otherGuild = JS::GetMaybePtrFromReservedSlot<CGuild>( otherObj , 0 );
+	auto *otherGuild = GetWrappedObject<CGuild>( args.get( 0 ), &UOXGuild_class );
 	if( otherGuild == nullptr )
 	{
 		ScriptError( cx, "IsNeutral: Invalid target Guild object" );
@@ -5075,7 +5083,7 @@ bool CBase_InRange( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-  auto *them = JS::GetMaybePtrFromReservedSlot<CBaseObject>( &args.get(0).toObject(), 0 );
+	auto *them = GetBaseObject( args.get( 0 ));
 	if( !ValidateObject( them ))
 	{
 		ScriptError( cx, "(InRange) Invalid Object assigned to target" );
@@ -5537,8 +5545,7 @@ bool CChar_SpeechInput( JSContext *cx, unsigned argc, JS::Value* vp )
 
 		if( args.get(1) != JS::NullValue() )
 		{
-			JSObject *myObj = &args.get(1).toObject();
-			speechItem = JS::GetMaybePtrFromReservedSlot<CItem>( myObj, 0 );
+			speechItem = GetWrappedObject<CItem>( args.get( 1 ), &UOXItem_class );
 		}
 	}
 	else
@@ -5799,7 +5806,7 @@ bool CChar_SetPoisoned( JSContext *cx, unsigned argc, JS::Value* vp )
 
 		if( argc >= 3 )
 		{
-  auto *poisonSourceChar = JS::GetMaybePtrFromReservedSlot<CChar>( &args.get(2).toObject(), 0 );
+	auto *poisonSourceChar = GetWrappedObject<CChar>( args.get( 2 ), &UOXChar_class );
 			if( !ValidateObject( poisonSourceChar ))
 			{
 				ScriptError( cx, "(SetPoisoned) Invalid Object passed as third function parameter" );
@@ -5836,8 +5843,7 @@ bool CChar_ExplodeItem( JSContext *cx, unsigned argc, JS::Value* vp )
 	auto args = JS::CallArgsFromVp(argc, vp);
 	auto  obj = getThis( cx, args );
   CChar *myChar = JS::GetMaybePtrFromReservedSlot<CChar>( obj, 0 );
-	JSObject *tObj = &args.get(0).toObject();
-  CBaseObject  *trgObj = JS::GetMaybePtrFromReservedSlot<CBaseObject >( tObj, 0 );
+	CBaseObject *trgObj = GetBaseObject( args.get( 0 ));
 
 	if( !ValidateObject( trgObj ) || trgObj->GetObjType() != OT_ITEM || myChar->GetSocket() == nullptr )
 	{
@@ -5893,8 +5899,7 @@ bool CItem_SetCont( JSContext *cx, unsigned argc, JS::Value* vp )
 	auto args = JS::CallArgsFromVp(argc, vp);
 	auto  obj = getThis( cx, args );
   CItem *myItem = JS::GetMaybePtrFromReservedSlot<CItem>( obj, 0 );
-	JSObject *tObj = &args.get(0).toObject();
-  CBaseObject  *trgObj = JS::GetMaybePtrFromReservedSlot<CBaseObject >( tObj, 0 );
+	CBaseObject *trgObj = GetBaseObject( args.get( 0 ));
 
 	if( !ValidateObject( myItem ) || !ValidateObject( trgObj ) || ( trgObj->GetSerial() == INVALIDSERIAL ))
 	{
@@ -5991,7 +5996,7 @@ bool CMulti_IsInMulti( JSContext *cx, unsigned argc, JS::Value* vp )
 		args.rval().setBoolean( false );
 		return true;
 	}
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CBaseObject >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetBaseObject( args.get( 0 ));
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "(IsInMulti) Invalid object in house" );
@@ -6028,7 +6033,7 @@ bool CMulti_IsOnBanList( JSContext *cx, unsigned argc, JS::Value* vp )
 		args.rval().setBoolean( false );
 		return true;
 	}
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "(IsOnBanList) Invalid character" );
@@ -6065,7 +6070,7 @@ bool CMulti_IsOnFriendList( JSContext *cx, unsigned argc, JS::Value* vp )
 		args.rval().setBoolean( false );
 		return true;
 	}
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "(IsOnFriendList) Invalid character" );
@@ -6102,7 +6107,7 @@ bool CMulti_IsOnGuestList( JSContext *cx, unsigned argc, JS::Value* vp )
 		args.rval().setBoolean( false );
 		return true;
 	}
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "(IsOnGuestList) Invalid character" );
@@ -6139,7 +6144,7 @@ bool CMulti_IsOnOwnerList( JSContext *cx, unsigned argc, JS::Value* vp )
 		args.rval().setBoolean( false );
 		return true;
 	}
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "(IsOnOwnerList) Invalid character" );
@@ -6176,7 +6181,7 @@ bool CMulti_IsOwner( JSContext *cx, unsigned argc, JS::Value* vp )
 		args.rval().setBoolean( false );
 		return true;
 	}
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "(IsOwner) Invalid character" );
@@ -6211,7 +6216,7 @@ bool CMulti_AddToBanList( JSContext *cx, unsigned argc, JS::Value* vp )
 		ScriptError( cx, "(AddToBanList) Invalid object assigned" );
 		return false;
 	}
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "(AddToBanList) Invalid character" );
@@ -6248,7 +6253,7 @@ bool CMulti_AddToFriendList( JSContext *cx, unsigned argc, JS::Value* vp )
 		args.rval().setBoolean( false );
 		return true;
 	}
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "(AddToFriendList) Invalid character" );
@@ -6286,7 +6291,7 @@ bool CMulti_AddToGuestList( JSContext *cx, unsigned argc, JS::Value* vp )
 		args.rval().setBoolean( false );
 		return true;
 	}
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "(AddToGuestList) Invalid character" );
@@ -6324,7 +6329,7 @@ bool CMulti_AddToOwnerList( JSContext *cx, unsigned argc, JS::Value* vp )
 		args.rval().setBoolean( false );
 		return true;
 	}
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "(AddToOwnerList) Invalid character" );
@@ -6362,7 +6367,7 @@ bool CMulti_RemoveFromBanList( JSContext *cx, unsigned argc, JS::Value* vp )
 		args.rval().setBoolean( false );
 		return true;
 	}
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "(RemoveFromBanList) Invalid character" );
@@ -6400,7 +6405,7 @@ bool CMulti_RemoveFromFriendList( JSContext *cx, unsigned argc, JS::Value* vp )
 		args.rval().setBoolean( false );
 		return true;
 	}
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "(RemoveFromFriendList) Invalid character" );
@@ -6438,7 +6443,7 @@ bool CMulti_RemoveFromGuestList( JSContext *cx, unsigned argc, JS::Value* vp )
 		args.rval().setBoolean( false );
 		return true;
 	}
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "(RemoveFromGuestList) Invalid character" );
@@ -6476,7 +6481,7 @@ bool CMulti_RemoveFromOwnerList( JSContext *cx, unsigned argc, JS::Value* vp )
 		args.rval().setBoolean( false );
 		return true;
 	}
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "(RemoveFromOwnerList) Invalid character" );
@@ -6891,8 +6896,7 @@ bool CSocket_GetString( JSContext *cx, unsigned argc, JS::Value* vp )
 		strcopy( toReturn, 128, ( char * ) & ( mSock->Buffer() )[offset] );
 	}
 
-	JSString *strSpeech = nullptr;
-	strSpeech = JS_NewStringCopyZ( cx, toReturn );
+	JS::RootedString strSpeech( cx, JS_NewStringCopyZ( cx, toReturn ));
 	args.rval().setString( strSpeech );
 
 	return true;
@@ -7303,7 +7307,7 @@ bool CRace_CanWearArmour( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-  auto *toFind = JS::GetMaybePtrFromReservedSlot<CItem >( &args.get(0).toObject(), 0 );
+	auto *toFind = GetWrappedObject<CItem>( args.get( 0 ), &UOXItem_class );
 	if( !ValidateObject( toFind ))
 	{
 		ScriptError( cx, "CanWearArmour: Invalid item passed" );
@@ -8734,8 +8738,7 @@ bool CBase_DistanceTo( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-	JSObject *jsObj		= &args.get(0).toObject();
-  auto *myObj = JS::GetMaybePtrFromReservedSlot<CBaseObject >( jsObj , 0 );
+	auto *myObj = GetBaseObject( args.get( 0 ));
 
   CBaseObject *thisObj = JS::GetMaybePtrFromReservedSlot<CBaseObject>( obj, 0 );
 
@@ -8759,8 +8762,7 @@ bool CItem_Glow( JSContext *cx, unsigned argc, JS::Value* vp )
 {
 	auto args = JS::CallArgsFromVp(argc, vp);
 	auto  obj = getThis( cx, args );
-	JSObject *mSock	= &args.get(0).toObject();
-  auto *mySock = JS::GetMaybePtrFromReservedSlot<CSocket >( mSock , 0 );
+	auto *mySock = GetWrappedObject<CSocket>( args.get( 0 ), &UOXSocket_class );
 
   CItem *mItem = JS::GetMaybePtrFromReservedSlot<CItem>( obj, 0 );
 
@@ -8816,8 +8818,7 @@ bool CItem_UnGlow( JSContext *cx, unsigned argc, JS::Value* vp )
 {
 	auto args = JS::CallArgsFromVp(argc, vp);
 	auto  obj = getThis( cx, args );
-	JSObject *mSock	= &args.get(0).toObject();
-  auto *mySock = JS::GetMaybePtrFromReservedSlot<CSocket >( mSock , 0 );
+	auto *mySock = GetWrappedObject<CSocket>( args.get( 0 ), &UOXSocket_class );
 
   CItem *mItem = JS::GetMaybePtrFromReservedSlot<CItem>( obj, 0 );
 
@@ -8890,8 +8891,7 @@ bool CChar_Gate( JSContext *cx, unsigned argc, JS::Value* vp )
 	{
 		if( args.get(0).isObject() )
 		{
-			JSObject *jsObj		= &args.get(0).toObject();
-  auto *mItem	 = JS::GetMaybePtrFromReservedSlot<CItem >( jsObj , 0 );
+			auto *mItem = GetWrappedObject<CItem>( args.get( 0 ), &UOXItem_class );
 			if( !ValidateObject( mItem ))
 			{
 				ScriptError( cx, "Gate: Invalid item passed" );
@@ -8962,8 +8962,7 @@ bool CChar_Recall( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-	JSObject *jsObj		= &args.get(0).toObject();
-  auto *mItem	 = JS::GetMaybePtrFromReservedSlot<CItem >( jsObj , 0 );
+	auto *mItem = GetWrappedObject<CItem>( args.get( 0 ), &UOXItem_class );
 	if( !ValidateObject( mItem ))
 	{
 		ScriptError( cx, "Recall: Invalid item passed" );
@@ -9016,8 +9015,7 @@ bool CChar_Mark( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-	JSObject *jsObj		= &args.get(0).toObject();
-  auto *mItem	 = JS::GetMaybePtrFromReservedSlot<CItem >( jsObj , 0 );
+	auto *mItem = GetWrappedObject<CItem>( args.get( 0 ), &UOXItem_class );
 	if( !ValidateObject( mItem ))
 	{
 		ScriptError( cx, "Mark: Invalid item passed" );
@@ -9235,18 +9233,16 @@ bool CItem_Dupe( JSContext *cx, unsigned argc, JS::Value* vp )
 	}
 
   CItem *mItem = JS::GetMaybePtrFromReservedSlot<CItem>( obj, 0 );
-	JSObject *jsObj	= &args.get(0).toObject();
-
 	CSocket *mSock = nullptr;
 	bool dupeInPack = true;
 
-	if( jsObj == nullptr )
+	if( args.get( 0 ).isNullOrUndefined() )
 	{
 		dupeInPack = false;
 	}
 	else
 	{
-		mSock = JS::GetMaybePtrFromReservedSlot<CSocket>( jsObj, 0 );
+		mSock = GetWrappedObject<CSocket>( args.get( 0 ), &UOXSocket_class );
 	}
 
 	if( !ValidateObject( mItem ) || ( mSock == nullptr && dupeInPack ))
@@ -9866,7 +9862,7 @@ bool CChar_SpellMoveEffect( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-  auto *mySpell = JS::GetMaybePtrFromReservedSlot<CSpellInfo >( &args.get(1).toObject(), 0 );
+	auto *mySpell = GetWrappedObject<CSpellInfo>( args.get( 1 ), &UOXSpell_class );
 	if( mySpell == nullptr )
 	{
 		ScriptError( cx, "SpellMoveEffect: Invalid spell" );
@@ -9874,7 +9870,7 @@ bool CChar_SpellMoveEffect( JSContext *cx, unsigned argc, JS::Value* vp )
 	}
 
   CChar *source = JS::GetMaybePtrFromReservedSlot<CChar>( obj, 0 );
-  auto *target = JS::GetMaybePtrFromReservedSlot<CBaseObject >( &args.get(0).toObject(), 0 );
+	auto *target = GetBaseObject( args.get( 0 ));
 	if( !ValidateObject( source ) || !ValidateObject( target ))
 	{
 		ScriptError( cx, "SpellMoveEffect: Invalid object passed" );
@@ -9914,7 +9910,7 @@ bool CChar_SpellStaticEffect( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-  auto *mySpell = JS::GetMaybePtrFromReservedSlot<CSpellInfo >( &args.get(0).toObject(), 0 );
+	auto *mySpell = GetWrappedObject<CSpellInfo>( args.get( 0 ), &UOXSpell_class );
 	if( mySpell == nullptr )
 	{
 		ScriptError( cx, "SpellStaticEffect: Invalid spell" );
@@ -9958,7 +9954,7 @@ bool CChar_BreakConcentration( JSContext *cx, unsigned argc, JS::Value* vp )
 	CSocket *mSock = nullptr;
 	if( argc == 1 )
 	{
-		mSock = JS::GetMaybePtrFromReservedSlot<CSocket>( &args.get(0).toObject(), 0 );
+		mSock = GetWrappedObject<CSocket>( args.get( 0 ), &UOXSocket_class );
 		if( mSock == nullptr )
 		{
 			ScriptError( cx, "BreakConcentration: Invalid socket" );
@@ -10073,7 +10069,7 @@ bool CItem_Carve( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-  auto *mSock = JS::GetMaybePtrFromReservedSlot<CSocket >( &args.get(0).toObject(), 0 );
+	auto *mSock = GetWrappedObject<CSocket>( args.get( 0 ), &UOXSocket_class );
 	if( mSock == nullptr )
 	{
 		ScriptError( cx, "Carve: Invalid socket" );
@@ -10109,8 +10105,7 @@ bool CItem_GetTileName( JSContext *cx, unsigned argc, JS::Value* vp )
 	std::string itemName = "";
 	GetTileName(( *mItem ), itemName );
 
-	JSString *tString;
-	tString = JS_NewStringCopyZ( cx, itemName.c_str() );
+	JS::RootedString tString( cx, JS_NewStringCopyZ( cx, itemName.c_str() ));
 	args.rval().setString( tString );
 	return true;
 }
@@ -10201,7 +10196,7 @@ bool CMulti_SecureContainer( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-  auto *itemToSecure = JS::GetMaybePtrFromReservedSlot<CItem>( &args.get(0).toObject(), 0 );
+	auto *itemToSecure = GetWrappedObject<CItem>( args.get( 0 ), &UOXItem_class );
 	if( !ValidateObject( itemToSecure ))
 	{
 		ScriptError( cx, "(SecureContainer) Invalid Object passed" );
@@ -10244,7 +10239,7 @@ bool CMulti_UnsecureContainer( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-  auto *itemToUnsecure = JS::GetMaybePtrFromReservedSlot<CItem>( &args.get(0).toObject(), 0 );
+	auto *itemToUnsecure = GetWrappedObject<CItem>( args.get( 0 ), &UOXItem_class );
 	if( !ValidateObject( itemToUnsecure ))
 	{
 		ScriptError( cx, "(UnsecureContainer) Invalid Object passed" );
@@ -10287,7 +10282,7 @@ bool CMulti_IsSecureContainer( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-  auto *itemToCheck = JS::GetMaybePtrFromReservedSlot<CItem>( &args.get(0).toObject(), 0 );
+	auto *itemToCheck = GetWrappedObject<CItem>( args.get( 0 ), &UOXItem_class );
 	if( !ValidateObject( itemToCheck ))
 	{
 		ScriptError( cx, "(IsSecureContainer) Invalid Object passed" );
@@ -10330,7 +10325,7 @@ bool CMulti_LockDownItem( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-  auto *itemToLockDown = JS::GetMaybePtrFromReservedSlot<CItem>( &args.get(0).toObject(), 0 );
+	auto *itemToLockDown = GetWrappedObject<CItem>( args.get( 0 ), &UOXItem_class );
 	if( !ValidateObject( itemToLockDown ))
 	{
 		ScriptError( cx, "(LockDownItem) Invalid item object passed" );
@@ -10373,7 +10368,7 @@ bool CMulti_ReleaseItem( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-  auto *itemToRemove = JS::GetMaybePtrFromReservedSlot<CItem>( &args.get(0).toObject(), 0 );
+	auto *itemToRemove = GetWrappedObject<CItem>( args.get( 0 ), &UOXItem_class );
 	if( !ValidateObject( itemToRemove ))
 	{
 		ScriptError( cx, "(ReleaseItem) Invalid item object passed" );
@@ -10416,7 +10411,7 @@ bool CMulti_AddTrashCont( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-  auto *itemToLockDown = JS::GetMaybePtrFromReservedSlot<CItem>( &args.get(0).toObject(), 0 );
+	auto *itemToLockDown = GetWrappedObject<CItem>( args.get( 0 ), &UOXItem_class );
 	if( !ValidateObject( itemToLockDown ))
 	{
 		ScriptError( cx, "(AddTrashCont) Invalid item object passed" );
@@ -10459,7 +10454,7 @@ bool CMulti_RemoveTrashCont( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-  auto *itemToRemove = JS::GetMaybePtrFromReservedSlot<CItem>( &args.get(0).toObject(), 0 );
+	auto *itemToRemove = GetWrappedObject<CItem>( args.get( 0 ), &UOXItem_class );
 	if( !ValidateObject( itemToRemove ))
 	{
 		ScriptError( cx, "(RemoveTrashCont) Invalid item object passed" );
@@ -10502,7 +10497,7 @@ bool CMulti_AddVendor( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-  auto *vendorToAdd = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *vendorToAdd = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( vendorToAdd ))
 	{
 		ScriptError( cx, "(AddVendor) Invalid character object passed" );
@@ -10545,7 +10540,7 @@ bool CMulti_RemoveVendor( JSContext *cx, unsigned argc, JS::Value* vp )
 		return false;
 	}
 
-  auto *vendorToRemove = JS::GetMaybePtrFromReservedSlot<CChar >( &args.get(0).toObject(), 0 );
+	auto *vendorToRemove = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( vendorToRemove ))
 	{
 		ScriptError( cx, "(RemoveVendor) Invalid character object passed" );
@@ -10585,8 +10580,7 @@ bool CMulti_KillKeys( JSContext *cx, unsigned argc, JS::Value* vp )
 
 	if( argc == 1 )
 	{
-		JSObject *jsObj = &args.get(0).toObject();
-  auto *myObj = JS::GetMaybePtrFromReservedSlot<CChar >( jsObj , 0 );
+		auto *myObj = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 		
 		if( !ValidateObject( myObj ))
 		{
@@ -11116,7 +11110,7 @@ bool CChar_InitiateCombat( JSContext *cx, unsigned argc, JS::Value* vp )
 		return true;
 	}
 
-  auto *ourTarget = JS::GetMaybePtrFromReservedSlot<CChar>( &args.get(0).toObject(), 0 );
+	auto *ourTarget = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( ourTarget ))
 	{
 		ScriptError( cx, "(InitiateCombat): Operating on an invalid Character" );
@@ -11177,7 +11171,7 @@ bool CChar_AddAggressorFlag( JSContext *cx, unsigned argc, JS::Value* vp )
 		return true;
 	}
 
-  auto *ourTarget = JS::GetMaybePtrFromReservedSlot<CChar>( &args.get(0).toObject(), 0 );
+	auto *ourTarget = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( ourTarget ))
 	{
 		ScriptError( cx, "(AddAggressorFlag): Operating on an invalid Character (arg 0)" );
@@ -11211,7 +11205,7 @@ bool CChar_RemoveAggressorFlag( JSContext *cx, unsigned argc, JS::Value* vp )
 		return true;
 	}
 
-  auto *ourTarget = JS::GetMaybePtrFromReservedSlot<CChar>( &args.get(0).toObject(), 0 );
+	auto *ourTarget = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( ourTarget ))
 	{
 		ScriptError( cx, "(RemoveAggressorFlag): Operating on an invalid Character (arg 0)" );
@@ -11245,7 +11239,7 @@ bool CChar_CheckAggressorFlag( JSContext *cx, unsigned argc, JS::Value* vp )
 		return true;
 	}
 
-  auto *ourTarget = JS::GetMaybePtrFromReservedSlot<CChar>( &args.get(0).toObject(), 0 );
+	auto *ourTarget = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( ourTarget ))
 	{
 		ScriptError( cx, "(CheckAggressorFlag): Operating on an invalid Character (arg 0)" );
@@ -11279,7 +11273,7 @@ bool CChar_UpdateAggressorFlagTimestamp( JSContext *cx, unsigned argc, JS::Value
 		return true;
 	}
 
-  auto *ourTarget = JS::GetMaybePtrFromReservedSlot<CChar>( &args.get(0).toObject(), 0 );
+	auto *ourTarget = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( ourTarget ))
 	{
 		ScriptError( cx, "(UpdateAggressorFlagTimestamp): Operating on an invalid Character (arg 0)" );
@@ -11370,7 +11364,7 @@ bool CChar_AddPermaGreyFlag( JSContext *cx, unsigned argc, JS::Value* vp )
 		return true;
 	}
 
-  auto *ourTarget = JS::GetMaybePtrFromReservedSlot<CChar>( &args.get(0).toObject(), 0 );
+	auto *ourTarget = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( ourTarget ))
 	{
 		ScriptError( cx, "(AddPermaGreyFlag): Operating on an invalid Character (arg 0)" );
@@ -11404,7 +11398,7 @@ bool CChar_RemovePermaGreyFlag( JSContext *cx, unsigned argc, JS::Value* vp )
 		return true;
 	}
 
-  auto *ourTarget = JS::GetMaybePtrFromReservedSlot<CChar>( &args.get(0).toObject(), 0 );
+	auto *ourTarget = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( ourTarget ))
 	{
 		ScriptError( cx, "(RemovePermaGreyFlag): Operating on an invalid Character (arg 0)" );
@@ -11438,7 +11432,7 @@ bool CChar_CheckPermaGreyFlag( JSContext *cx, unsigned argc, JS::Value* vp )
 		return true;
 	}
 
-  auto *ourTarget = JS::GetMaybePtrFromReservedSlot<CChar>( &args.get(0).toObject(), 0 );
+	auto *ourTarget = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( ourTarget ))
 	{
 		ScriptError( cx, "(CheckPermaGreyFlag): Operating on an invalid Character (arg 0)" );
@@ -11472,7 +11466,7 @@ bool CChar_UpdatePermaGreyFlagTimestamp( JSContext *cx, unsigned argc, JS::Value
 		return true;
 	}
 
-  auto *ourTarget = JS::GetMaybePtrFromReservedSlot<CChar>( &args.get(0).toObject(), 0 );
+	auto *ourTarget = GetWrappedObject<CChar>( args.get( 0 ), &UOXChar_class );
 	if( !ValidateObject( ourTarget ))
 	{
 		ScriptError( cx, "(UpdatePermaGreyFlagTimestamp): Operating on an invalid Character (arg 0)" );

--- a/source/UOXJSPropertyFuncs.cpp
+++ b/source/UOXJSPropertyFuncs.cpp
@@ -1836,7 +1836,7 @@ FDCLG( CSpawnRegion, attr )                                           \
 	FNARGS                                                             \
 	auto region = JS::GetMaybePtrFromReservedSlot<CSpawnRegion>( thisObj, 0 ); \
 	const std::string entries = JoinSpawnEntries( region->accessor() ); \
-	JSString *value = JS_NewStringCopyZ( cx, entries.c_str() );         \
+	JS::RootedString value( cx, JS_NewStringCopyZ( cx, entries.c_str() )); \
 	if( value == nullptr )                                              \
 		return false;                                                    \
 	args.rval().setString( value );                                     \
@@ -2379,7 +2379,7 @@ FDCLG( CAccount, lastIP )
 	auto account = JS::GetMaybePtrFromReservedSlot<CAccountBlock_st>( thisObj, 0 );
 	const UI32 ip = account->dwLastIP;
 	const std::string text = oldstrutil::format( "%u.%u.%u.%u", ( ip >> 24 ) & 0xFF, ( ip >> 16 ) & 0xFF, ( ip >> 8 ) & 0xFF, ip & 0xFF );
-	JSString *value = JS_NewStringCopyZ( cx, text.c_str() );
+	JS::RootedString value( cx, JS_NewStringCopyZ( cx, text.c_str() ));
 	if( value == nullptr ) return false;
 	args.rval().setString( value );
 	return true;

--- a/source/cScript.cpp
+++ b/source/cScript.cpp
@@ -18,6 +18,7 @@
 #include <js/Conversions.h>
 #include <js/ErrorReport.h>
 #include <js/Exception.h>
+#include <js/GCVector.h>
 #include <js/Warnings.h>
 
 static constexpr SI08 RV_NOFUNC = -1;
@@ -407,8 +408,8 @@ cScript::cScript( std::string targFile, UI08 rT, UI16 scrID ) : isFiring( false 
 		else
 		{
 			// Triggered when reloading individual scripts at runtime
-			JS::Value pendingException;
-			if( JS_GetPendingException( targContext, JS::MutableHandleValue::fromMarkedLocation(&pendingException) ) == true )
+			JS::RootedValue pendingException( targContext );
+			if( JS_GetPendingException( targContext, &pendingException ) == true )
 			{
 				if( pendingException.isObject() && !pendingException.isNull() )
 				{
@@ -513,9 +514,19 @@ bool cScript::InvokeEvent( const char* name, unsigned int argc, const JS::Value*
 	Console.Log( oldstrutil::format( "Triggering event '%s' from script %d", name, GetScriptID() ) );
 #endif
 	JS::RootedObject rootedObj( targContext, targObject );
-	auto args = JS::HandleValueArray::fromMarkedLocation( argc, argv );
-	auto result = JS::MutableHandleValue::fromMarkedLocation( rval );
-	bool rVal = JS_CallFunctionName( targContext, rootedObj, name, args, result );
+	JS::RootedValueVector rootedArgs( targContext );
+	if( argc > 0 && !rootedArgs.append( argv, argc ))
+	{
+		ReportPendingJSException( targContext );
+		JSMapping->popActive();
+		return false;
+	}
+	JS::RootedValue rootedResult( targContext );
+	bool rVal = JS_CallFunctionName( targContext, rootedObj, name, rootedArgs, &rootedResult );
+	if( rval != nullptr )
+	{
+		*rval = rootedResult;
+	}
 	if( !rVal )
 	{
 		ReportPendingJSException( targContext );
@@ -774,10 +785,8 @@ SI08 cScript::OnSpeech( const char *speech, CChar *personTalking, CBaseObject *t
 		return RV_NOFUNC;
 
 	JS::Value params[3], rval;
-	JSString *strSpeech 	= nullptr;
 	std::string lwrSpeech	= speech;
-
-	strSpeech = JS_NewStringCopyZ( targContext, oldstrutil::lower( lwrSpeech ).c_str() );
+	JS::RootedString strSpeech( targContext, JS_NewStringCopyZ( targContext, oldstrutil::lower( lwrSpeech ).c_str() ));
 
 	JSObject *ptObj = JSEngine->AcquireObject( IUE_CHAR, personTalking, runTime );
 	JSObject *ttObj = nullptr;
@@ -3211,8 +3220,7 @@ void cScript::HandleGumpInput( CPIGumpInput *pressing )
 
 	JS::Value params[3], rval;
 	JSObject *myObj = JSEngine->AcquireObject( IUE_SOCK, pressing->GetSocket(), runTime );
-	JSString *gumpReply = nullptr;
-	gumpReply = JS_NewStringCopyZ( targContext, pressing->Reply().c_str() );
+	JS::RootedString gumpReply( targContext, JS_NewStringCopyZ( targContext, pressing->Reply().c_str() ));
 	params[0] = JS::ObjectOrNullValue( myObj );
 	params[1] = JS::Int32Value( pressing->Index() );
 	params[2] = JS::StringValue( gumpReply );
@@ -3540,10 +3548,8 @@ SI08 cScript::OnTalk( CChar *myChar, const char *mySpeech )
 
 	JS::Value params[2], rval;
 
-	JSString *strSpeech		= nullptr;
 	std::string lwrSpeech	= mySpeech;
-
-	strSpeech = JS_NewStringCopyZ( targContext, oldstrutil::lower( lwrSpeech ).c_str() );
+	JS::RootedString strSpeech( targContext, JS_NewStringCopyZ( targContext, oldstrutil::lower( lwrSpeech ).c_str() ));
 
 	JSObject *charObj = JSEngine->AcquireObject( IUE_CHAR, myChar, runTime );
 
@@ -3577,11 +3583,9 @@ bool cScript::OnSpeechInput( CChar *myChar, CItem *myItem, const char *mySpeech 
 		return true;
 
 	JS::Value params[4], rval;
-	JSString *strSpeech = nullptr;
-
 	char *lwrSpeech = new char[strlen( mySpeech ) + 1];
 	strcopy( lwrSpeech, strlen( mySpeech ) + 1, mySpeech );
-	strSpeech = JS_NewStringCopyZ( targContext, lwrSpeech );
+	JS::RootedString strSpeech( targContext, JS_NewStringCopyZ( targContext, lwrSpeech ));
 	delete[] lwrSpeech;
 
 	JSObject *charObj = JSEngine->AcquireObject( IUE_CHAR, myChar, runTime );
@@ -3785,8 +3789,7 @@ SI08 cScript::OnCommand( CSocket *mSock, std::string command )
 
 	JS::Value params[2], rval;
 	JSObject *myObj = JSEngine->AcquireObject( IUE_SOCK, mSock, runTime );
-	JSString *strCmd = nullptr;
-	strCmd = JS_NewStringCopyZ( targContext, oldstrutil::lower( command ).c_str() );
+	JS::RootedString strCmd( targContext, JS_NewStringCopyZ( targContext, oldstrutil::lower( command ).c_str() ));
 	params[0]	= JS::ObjectOrNullValue( myObj );
 	params[1]	= JS::StringValue( strCmd );
 	bool retVal	= InvokeEvent( "onCommand", 2, params, &rval );
@@ -3858,8 +3861,7 @@ SI08 cScript::OnProfileUpdate( CSocket *mSock, std::string profileText )
 
 	JS::Value params[2], rval;
 	JSObject *myObj = JSEngine->AcquireObject( IUE_SOCK, mSock, runTime );
-	JSString *strProfileText = nullptr;
-	strProfileText = JS_NewStringCopyZ( targContext, profileText.c_str() );
+	JS::RootedString strProfileText( targContext, JS_NewStringCopyZ( targContext, profileText.c_str() ));
 
 	params[0]	= JS::ObjectOrNullValue( myObj );
 	params[1]	= JS::StringValue( strProfileText );
@@ -3931,7 +3933,7 @@ bool cScript::ScriptRegistration( std::string scriptType )
 bool cScript::executeCommand( CSocket *s, std::string funcName, std::string executedString )
 {
 	JS::Value params[2], rval;
-	JSString *execString = JS_NewStringCopyZ( targContext, executedString.c_str() );
+	JS::RootedString execString( targContext, JS_NewStringCopyZ( targContext, executedString.c_str() ));
 	JSObject *myObj = JSEngine->AcquireObject( IUE_SOCK, s, runTime );
 	params[0] = JS::ObjectOrNullValue( myObj );
 	params[1] = JS::StringValue( execString );


### PR DESCRIPTION
- Initialize the missing individual account prototype so Account properties work.
- Properly root JavaScript event arguments, results, strings, globals, and singleton objects.
- Replace unsafe direct object conversions with class-aware wrapper validation.
- Improve invalid argument handling across global functions and object methods.
- Add a consolidated JavaScript test suite covering bindings, live objects, items, containers, garbage collection, timers, errors, and argument validation.
- Verify the changes with Release builds and runtime tests.