### PR TITLE
Wrappers makes it a wrap

### DIFF
--- a/source/SEFunctions.cpp
+++ b/source/SEFunctions.cpp
@@ -39,33 +39,6 @@
 #include <js/Array.h>
 #include <js/Conversions.h>
 
-namespace
-{
-bool HasWrapperClass( JS::HandleValue value, const JSClass *expectedClass )
-{
-	return value.isObject() && JS::GetClass( &value.toObject() ) == expectedClass;
-}
-
-template<typename T>
-T *GetWrappedObject( JS::HandleValue value, const JSClass *expectedClass )
-{
-	if( !HasWrapperClass( value, expectedClass ))
-		return nullptr;
-
-	return JS::GetMaybePtrFromReservedSlot<T>( &value.toObject(), 0 );
-}
-
-CBaseObject *GetBaseObject( JS::HandleValue value )
-{
-	CBaseObject *object = GetWrappedObject<CChar>( value, &UOXChar_class );
-	if( object == nullptr )
-		object = GetWrappedObject<CItem>( value, &UOXItem_class );
-
-	return object;
-}
-}
-
-
 void		LoadTeleportLocations( void );
 void		LoadSpawnRegions( void );
 void		LoadRegions( void );

--- a/source/UOXJSClasses.h
+++ b/source/UOXJSClasses.h
@@ -11,6 +11,9 @@
 #include "UOXJSPropertyFuncs.h"
 #include <js/Class.h>
 #include <js/GlobalObject.h>
+#include <js/Object.h>
+
+class CBaseObject;
 
 static constexpr JSClassOps classOpsWithFinalize = {
     nullptr,  // addProperty
@@ -256,5 +259,44 @@ inline JSClass UOXParty_class =
 	JSCLASS_HAS_RESERVED_SLOTS(2),
   &classOpsWithFinalize 
 };
+
+inline bool HasWrapperClass( JSObject *object, const JSClass *expectedClass )
+{
+	return object != nullptr && JS::GetClass( object ) == expectedClass;
+}
+
+inline bool HasWrapperClass( JS::HandleValue value, const JSClass *expectedClass )
+{
+	return value.isObject() && HasWrapperClass( value.toObjectOrNull(), expectedClass );
+}
+
+template<typename T>
+T *GetWrappedObject( JSObject *object, const JSClass *expectedClass )
+{
+	if( !HasWrapperClass( object, expectedClass ))
+		return nullptr;
+
+	return JS::GetMaybePtrFromReservedSlot<T>( object, 0 );
+}
+
+template<typename T>
+T *GetWrappedObject( JS::HandleValue value, const JSClass *expectedClass )
+{
+	return value.isObject() ? GetWrappedObject<T>( value.toObjectOrNull(), expectedClass ) : nullptr;
+}
+
+inline CBaseObject *GetBaseObject( JSObject *object )
+{
+	if( !HasWrapperClass( object, &UOXItem_class ) &&
+		!HasWrapperClass( object, &UOXChar_class ))
+		return nullptr;
+
+	return JS::GetMaybePtrFromReservedSlot<CBaseObject>( object, 0 );
+}
+
+inline CBaseObject *GetBaseObject( JS::HandleValue value )
+{
+	return value.isObject() ? GetBaseObject( value.toObjectOrNull() ) : nullptr;
+}
 
 #endif

--- a/source/UOXJSMethods.cpp
+++ b/source/UOXJSMethods.cpp
@@ -72,46 +72,6 @@ inline JSObject* getThis( JSContext * cx, JS::CallArgs& args )
 
 namespace
 {
-bool HasWrapperClass( JSObject *object, const JSClass *expectedClass )
-{
-	return object != nullptr && JS::GetClass( object ) == expectedClass;
-}
-
-bool HasWrapperClass( JS::HandleValue value, const JSClass *expectedClass )
-{
-	return value.isObject() && HasWrapperClass( &value.toObject(), expectedClass );
-}
-
-template<typename T>
-T *GetWrappedObject( JSObject *object, const JSClass *expectedClass )
-{
-	if( !HasWrapperClass( object, expectedClass ))
-		return nullptr;
-
-	return JS::GetMaybePtrFromReservedSlot<T>( object, 0 );
-}
-
-template<typename T>
-T *GetWrappedObject( JS::HandleValue value, const JSClass *expectedClass )
-{
-	return value.isObject() ? GetWrappedObject<T>( &value.toObject(), expectedClass ) : nullptr;
-}
-
-CBaseObject *GetBaseObject( JSObject *object )
-{
-	if( HasWrapperClass( object, &UOXChar_class ))
-		return JS::GetMaybePtrFromReservedSlot<CChar>( object, 0 );
-	if( HasWrapperClass( object, &UOXItem_class ))
-		return JS::GetMaybePtrFromReservedSlot<CItem>( object, 0 );
-
-	return nullptr;
-}
-
-CBaseObject *GetBaseObject( JS::HandleValue value )
-{
-	return value.isObject() ? GetBaseObject( &value.toObject() ) : nullptr;
-}
-
 std::string ConsoleValueToString( JSContext *cx, JS::HandleValue value )
 {
 	if( value.isObject() )


### PR DESCRIPTION
Centralized helpers in UOXJSClasses.h.
Removed duplicate implementations from SEFunctions.cpp and UOXJSMethods.cpp. GetBaseObject() checks items first, then characters. Uses toObjectOrNull().
Retrieves the shared pointer as CBaseObject *.