### PR TITLE
Fixed an incorrect mapping-section check in CJSMapping::Cleanup().

### DIFF
--- a/source/CJSMapping.cpp
+++ b/source/CJSMapping.cpp
@@ -71,7 +71,7 @@ void CJSMapping::Cleanup( void )
 {
 	for( size_t i = SCPT_NORMAL; i < SCPT_COUNT; ++i )
 	{
-		if( mapSection[1] != nullptr )
+		if( mapSection[i] != nullptr )
 		{
 			delete mapSection[i];
 			mapSection[i] = nullptr;


### PR DESCRIPTION
Fixed an incorrect mapping-section check in CJSMapping::Cleanup(). 
The cleanup loop iterates through every JavaScript mapping section using i, but the previous condition always checked 

mapSection[1]: if( mapSection[1] != nullptr )

This meant cleanup behavior for every section depended on the state of one hardcoded section rather than the section currently being processed. The condition now checks the matching loop entry:

if( mapSection[i] != nullptr )

Why this was needed
If mapSection[1] was null while other mapping sections still existed, the old code would skip deleting all remaining sections. 
Those sections contain script mappings and owned cScript instances, so skipping their destruction could retain script-related resources during cleanup or a full JavaScript reload. 
If mapSection[1] existed while another section was null, the loop would still attempt to delete that null entry. Deleting a null pointer is safe in C++, but the condition was still logically incorrect and did not validate the object being processed.