### PR TITLE
Main thread: running every script’s onScriptLoad and onStart

### DIFF
--- a/source/uox3.cpp
+++ b/source/uox3.cpp
@@ -681,12 +681,6 @@ auto StartInitialize( CServerData &serverdata ) -> void
 
 	Console.Log( "-=Server Startup=-\n=======================================================================", "server.log" );
 
-	Console << "Creating and Initializing Console Thread      ";
-
-	cons = std::thread( &CheckConsoleKeyThread );
-
-	Console.PrintDone();
-
 	// Shows information about IPs and ports being listened on
 	Console.TurnYellow();
 
@@ -781,6 +775,11 @@ auto StartInitialize( CServerData &serverdata ) -> void
 			}
 		}
 	}
+
+	Console << "Creating and Initializing Console Thread      ";
+	Console.Registration();
+	cons = std::thread( &CheckConsoleKeyThread );
+	Console.PrintDone();
 
 	// Get a second timestamp for startup time
 	auto startupEndTime = std::chrono::high_resolution_clock::now();
@@ -1036,7 +1035,6 @@ auto NetworkPollConnectionThread() -> void
 auto CheckConsoleKeyThread() -> void
 {
 	messageLoop << "Thread: CheckConsoleThread has started";
-	Console.Registration();
 	conThreadCloseOk = false;
 	while( !conThreadCloseOk )
 	{


### PR DESCRIPTION
During startup, two threads were using the same SpiderMonkey context: Main thread: running every script’s onScriptLoad and onStart. Console thread: running Console.Registration() and compiling console-script registration functions. SpiderMonkey 115 cannot safely perform those operations concurrently on the same context, causing the crash inside js::LifoAlloc::release(). I changed startup order so UOX3 now:
Runs all onScriptLoad events.
Runs all object and region onStart events.
Registers the JavaScript console commands on the main thread. Starts the console input thread only after that JavaScript work finishes. Nothing was removed or disabled. Champions, the Event Manager, console commands, and console-script registration remain enabled.