### PR TITLE
Misc updates

### DIFF
--- a/make/VS2022/uox3.vcxproj
+++ b/make/VS2022/uox3.vcxproj
@@ -66,6 +66,7 @@
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;_CONSOLE;JS_STANDALONE;STATIC_JS_API;_CRT_NO_VA_START_VALIDATION;_ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(MozjsLibrary);ws2_32.lib;Kernel32.lib;winmm.lib;psapi.lib;user32.lib;dbghelp.lib;legacy_stdio_definitions.lib;ntdll.lib;userenv.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/source/CJSEngine.cpp
+++ b/source/CJSEngine.cpp
@@ -44,7 +44,7 @@ void UOX3EngineWarningReporter(JSContext* cx, JSErrorReport* report)
 auto CJSEngine::Startup() -> void
 {
 	runtimeList.resize( 0 );
-  const UI32 maxEngineSize = JS::DefaultHeapMaxBytes;
+	const UI32 maxEngineSize = 0xFFFFFFFF; // 4 gb, hard max
 
 	// 16 MB minimum. Any lower and UOX3 is prone to crashes from frequent JS reloads
 	auto maxBytesSize = std::max( static_cast<UI16>( 16 ), cwmWorldState->ServerData()->GetJSEngineSize() ); // from INI
@@ -356,7 +356,7 @@ bool CJSRuntime::InitializePrototypes()
   JSContext *cx = jsContext;
   JS::RootedObject obj(jsContext, jsGlobal);
 
-  protoList = new JS::RootedObjectVector( cx );
+  protoList = new JS::PersistentRootedObjectVector( cx );
   if( !protoList->resize( JSP_COUNT ))
   {
     return false;

--- a/source/CJSEngine.h
+++ b/source/CJSEngine.h
@@ -56,7 +56,7 @@ private:
 	using JSOBJECTMAP_CITERATOR = JSOBJECTMAP::const_iterator;
 
 	std::array<JSOBJECTMAP, IUE_COUNT>					objectList;
-    JS::RootedObjectVector *   protoList;
+	JS::PersistentRootedObjectVector *protoList;
 
 	JSRuntime * jsRuntime;
 	JSContext * jsContext;

--- a/source/CJSMapping.cpp
+++ b/source/CJSMapping.cpp
@@ -230,15 +230,8 @@ CJSMappingSection * CJSMapping::GetSection( SCRIPTTYPE toGet )
 //o------------------------------------------------------------------------------------------------o
 UI16 CJSMapping::GetScriptId( JSObject *toFind )
 {
-	UI16 retVal	= 0xFFFF;
-
-	for( size_t i = SCPT_NORMAL; i < SCPT_COUNT; ++i )
-	{
-		retVal = mapSection[i]->GetScriptId( toFind );
-		if( retVal != 0xFFFF )
-			break;
-	}
-	return retVal;
+	cScript *script = GetScript( toFind );
+	return script != nullptr ? script->GetScriptID() : 0xFFFF;
 }
 
 //o------------------------------------------------------------------------------------------------o
@@ -249,19 +242,29 @@ UI16 CJSMapping::GetScriptId( JSObject *toFind )
 //o------------------------------------------------------------------------------------------------o
 cScript * CJSMapping::GetScript( JSObject *toFind )
 {
-	cScript *retVal		= nullptr;
-	cScript *toCheck	= nullptr;
+	if( toFind == nullptr )
+		return nullptr;
 
-	for( size_t i = SCPT_NORMAL; i < SCPT_COUNT; ++i )
+	const JSClass* objClass = JS::GetClass( toFind );
+	if( objClass != nullptr )
 	{
-		toCheck = mapSection[i]->GetScript( toFind );
-		if( toCheck != nullptr )
+		std::string className = objClass->name;
+		if( className == "uoxscript" )
 		{
-			retVal = toCheck;
-			break;
+			JS::Value slotVal = JS::GetReservedSlot( toFind, 0 );
+			if( !slotVal.isUndefined() )
+			{
+				return static_cast<cScript*>( slotVal.toPrivate() );
+			}
+		}
+		else
+		{
+			// The engine is passing something else! Let's find out what it is:
+			Console.Print( oldstrutil::format( "WARNING: GetScript expected 'uoxscript' but received: '%s'\n", className.c_str() ) );
 		}
 	}
-	return retVal;
+
+	return nullptr; 
 }
 
 //o------------------------------------------------------------------------------------------------o
@@ -319,7 +322,6 @@ CJSMappingSection::CJSMappingSection( SCRIPTTYPE sT )
 	scriptType = sT;
 
 	scriptIdMap.clear();
-	scriptJSMap.clear();
 
 	scriptIdIter = scriptIdMap.end();
 }
@@ -336,7 +338,6 @@ CJSMappingSection::~CJSMappingSection()
 	}
 
 	scriptIdMap.clear();
-	scriptJSMap.clear();
 }
 
 //o------------------------------------------------------------------------------------------------o
@@ -381,7 +382,6 @@ auto CJSMappingSection::Parse( Script *fileAssocData ) -> void
 					if( toAdd )
 					{
 						scriptIdMap[scriptId]			= toAdd;
-						scriptJSMap[toAdd->Object()]	= scriptId;
 						++i;
 					}
 				}
@@ -457,13 +457,6 @@ auto CJSMappingSection::Reload( UI16 toLoad ) -> void
 							{
 								if( scriptIdMap[toLoad] )
 								{
-									JSObject *jsObj = scriptIdMap[toLoad]->Object();
-									std::map<JSObject *, UI16>::iterator jFind = scriptJSMap.find( jsObj );
-									if( jFind != scriptJSMap.end() )
-									{
-										scriptJSMap.erase( jFind );
-									}
-
 									delete scriptIdMap[toLoad];
 									scriptIdMap[toLoad] = nullptr;
 								}
@@ -472,7 +465,6 @@ auto CJSMappingSection::Reload( UI16 toLoad ) -> void
 							if( toAdd )
 							{
 								scriptIdMap[scriptId]			= toAdd;
-								scriptJSMap[toAdd->Object()]	= scriptId;
 								Console.Print( oldstrutil::format( "Reload of JavaScript (ScriptId %u) Successful\n", toLoad ));
 								toAdd->OnScriptLoad();
 							}
@@ -521,15 +513,8 @@ bool CJSMappingSection::IsInMap( UI16 scriptId )
 //o------------------------------------------------------------------------------------------------o
 UI16 CJSMappingSection::GetScriptId( JSObject *toFind )
 {
-	UI16 retVal = 0xFFFF;
-
-	std::map<JSObject *, UI16>::const_iterator sIter = scriptJSMap.find( toFind );
-	if( sIter != scriptJSMap.end() )
-	{
-		retVal = sIter->second;
-	}
-
-	return retVal;
+	// Defer to the global mapping manager's O(1) slot extraction
+	return JSMapping->GetScriptId( toFind );
 }
 
 //o------------------------------------------------------------------------------------------------o
@@ -559,8 +544,8 @@ cScript * CJSMappingSection::GetScript( UI16 toFind )
 //o------------------------------------------------------------------------------------------------o
 cScript * CJSMappingSection::GetScript( JSObject *toFind )
 {
-	UI16 scriptId = GetScriptId( toFind );
-	return GetScript( scriptId );
+	// Defer to the global mapping manager's O(1) slot extraction
+	return JSMapping->GetScript( toFind );
 }
 
 //o------------------------------------------------------------------------------------------------o

--- a/source/CJSMapping.h
+++ b/source/CJSMapping.h
@@ -2,6 +2,7 @@
 #define __CJSMAPPING_H__
 
 #include <js/TypeDecls.h>
+#include "js/Object.h"
 
 #include <stack> 
 
@@ -22,7 +23,6 @@ class CJSMappingSection
 {
 private:
 	std::map<UI16, cScript *>			scriptIdMap;
-	std::map<JSObject *, UI16>			scriptJSMap;
 
 	std::map<UI16, cScript *>::iterator	scriptIdIter;
 
@@ -31,8 +31,6 @@ public:
 	CJSMappingSection( SCRIPTTYPE sT );
 	~CJSMappingSection();
 
-	auto jsCollection() const -> const std::map<JSObject*, UI16>& { return scriptJSMap; }
-	auto jsCollection()  -> std::map<JSObject*, UI16>& { return scriptJSMap; }
 	auto collection() const -> const std::map<UI16, cScript*>& { return scriptIdMap; }
 	auto collection()  -> std::map<UI16, cScript*>& { return scriptIdMap; }
 	

--- a/source/SEFunctions.cpp
+++ b/source/SEFunctions.cpp
@@ -807,7 +807,6 @@ bool SE_RegisterCommand( JSContext *cx, unsigned int argc, JS::Value *vp )
 bool SE_RegisterSpell( JSContext *cx, unsigned int argc, JS::Value *vp )
 {
 	auto args = JS::CallArgsFromVp(argc, vp);
-	auto scriptEnv = getThis( cx, args );
 
 	if( argc != 2 )
 	{
@@ -816,7 +815,13 @@ bool SE_RegisterSpell( JSContext *cx, unsigned int argc, JS::Value *vp )
 	}
 	SI32 spellNumber	= args.get(0).toInt32();
 	bool isEnabled		= ( args.get(1).toBoolean() == true );
-	cScript *myScript	= JSMapping->GetScript( scriptEnv );
+
+	cScript *myScript = JSMapping->currentActive();
+	if( myScript == nullptr )
+	{
+		ScriptError( cx, "RegisterSpell: JS Script could not be resolved" );
+		return false;
+	}
 	Magic->Register( myScript, spellNumber, isEnabled );
 	return true;
 }
@@ -917,7 +922,6 @@ bool SE_RegisterPacket( JSContext *cx, unsigned int argc, JS::Value *vp )
 bool SE_RegisterKey( JSContext *cx, unsigned int argc, JS::Value *vp )
 {
 	auto args = JS::CallArgsFromVp(argc, vp);
-	auto  scriptEnv = getThis( cx, args );
 
 	if( argc != 2 )
 	{
@@ -925,7 +929,12 @@ bool SE_RegisterKey( JSContext *cx, unsigned int argc, JS::Value *vp )
 		return false;
 	}
 	std::string toRegister	= JS_GetStringBytes( cx, args.get(1));
-	UI16 scriptId			= JSMapping->GetScriptId( scriptEnv );
+	UI16 scriptId = 0xFFFF;
+	cScript *activeScript = JSMapping->currentActive( false );
+	if( activeScript != nullptr )
+	{
+		scriptId = activeScript->GetScriptID();
+	}
 
 	if( scriptId == 0xFFFF )
 	{

--- a/source/UOXJSPropertyFuncs.cpp
+++ b/source/UOXJSPropertyFuncs.cpp
@@ -1760,7 +1760,17 @@ FDCLG( CCharacter, race ) { FNARGS auto character = JS::GetMaybePtrFromReservedS
 FDCLG( CCharacter, region ) { FNARGS auto character = JS::GetMaybePtrFromReservedSlot<CChar>( thisObj, 0 ); return SetCharacterObjectResult( cx, args.rval(), IUE_REGION, character->GetRegion() ); }
 FDCLG( CCharacter, town ) { FNARGS auto character = JS::GetMaybePtrFromReservedSlot<CChar>( thisObj, 0 ); const UI16 town = character->GetTown(); return SetCharacterObjectResult( cx, args.rval(), IUE_REGION, town == 0xFF ? nullptr : cwmWorldState->townRegions[town] ); }
 FDCLG( CCharacter, guild ) { FNARGS auto character = JS::GetMaybePtrFromReservedSlot<CChar>( thisObj, 0 ); const GUILDID guild = character->GetGuildNumber(); return SetCharacterObjectResult( cx, args.rval(), IUE_GUILD, guild == -1 ? nullptr : GuildSys->Guild( guild )); }
-FDCLG( CCharacter, socket ) { FNARGS auto character = JS::GetMaybePtrFromReservedSlot<CChar>( thisObj, 0 ); return SetCharacterObjectResult( cx, args.rval(), IUE_SOCK, character->GetSocket() ); }
+FDCLG( CCharacter, socket )
+{
+	FNARGS
+	auto character = JS::GetMaybePtrFromReservedSlot<CChar>( thisObj, 0 );
+	if (!ValidateObject( character ))
+	{
+		args.rval().setNull();
+		return true;
+	}
+	return SetCharacterObjectResult( cx, args.rval(), IUE_SOCK, character->GetSocket() );
+}
 FDCLG( CCharacter, party ) { FNARGS auto character = JS::GetMaybePtrFromReservedSlot<CChar>( thisObj, 0 ); return SetCharacterObjectResult( cx, args.rval(), IUE_PARTY, PartyFactory::GetSingleton().Get( character )); }
 FDCLG( CCharacter, multi ) { FNARGS auto character = JS::GetMaybePtrFromReservedSlot<CChar>( thisObj, 0 ); CMultiObj *multi = character->GetMultiObj(); return SetCharacterObjectResult( cx, args.rval(), IUE_ITEM, ValidateObject( multi ) ? multi : nullptr ); }
 FDCLG( CCharacter, account ) { FNARGS auto character = JS::GetMaybePtrFromReservedSlot<CChar>( thisObj, 0 ); return SetCharacterObjectResult( cx, args.rval(), IUE_ACCOUNT, &character->GetAccount() ); }

--- a/source/cScript.cpp
+++ b/source/cScript.cpp
@@ -4541,7 +4541,7 @@ SI16 cScript::OnCombatDamageCalc( CChar *attacker, CChar *defender, UI08 getFigh
 	SI16 funcRetVal	= -1;
 
 	JS::RootedValue rval( targContext );
-	JS::RootedValueArray<3> params( targContext );
+	JS::RootedValueArray<4> params( targContext );
 	JS::RootedObject attackerObj( targContext, JSEngine->AcquireObject( IUE_CHAR, attacker, runTime ) );
 	JS::RootedObject defenderObj( targContext, JSEngine->AcquireObject( IUE_CHAR, defender, runTime ) );
 	params[0].set( JS::ObjectOrNullValue( attackerObj ) );
@@ -4585,7 +4585,7 @@ SI08 cScript::OnDamage( CChar *damaged, CChar *attacker, SI16 damageValue, Weath
 		return RV_NOFUNC;
 
 	JS::RootedValue rval( targContext );
-	JS::RootedValueArray<3> params( targContext );
+	JS::RootedValueArray<4> params( targContext );
 	JS::RootedObject damagedObj( targContext, JSEngine->AcquireObject( IUE_CHAR, damaged, runTime ) );
 	params[0].set( JS::ObjectOrNullValue( damagedObj ) );
 	if( ValidateObject( attacker ))

--- a/source/cScript.cpp
+++ b/source/cScript.cpp
@@ -517,6 +517,15 @@ void cScript::CollectGarbage( void )
 cScript::~cScript()
 {
 	Cleanup();
+	if( scriptObj )
+	{
+		JS_SetReservedSlot( scriptObj, 0, JS::UndefinedValue() );
+	}
+
+	if( targObject )
+	{
+		JS_SetReservedSlot( targObject, 0, JS::UndefinedValue() );
+	}
 	targScript.reset();
 	scriptObj.reset();
 	targObject.reset();


### PR DESCRIPTION
- Changed protoList from heap-allocated JS::RootedObjectVector *to a JS::PersistentRootedObjectVector* for rooting safety
- Removed scriptJSMap in favor of accessing scripts and scriptIDs directly via reserved slots
- Restored JS engine's ability to set max memory usage based on INI setting rather than being hardcoded to 32MB
- Fixed exceptions with OnDamage and OnCombatDamageCalc JS Events caused by mismatch of param initialization and assignment
- Replaced fetching script environment with getThis() with JSMapping->currentActive() in SE_RegisterSpell() and SE_RegisterKey() for more explicit state tracking
- Added ValidateObject() to socket JS property getter for characters to fix a server exception
- Disabled optimization for Debug builds in VS2022 project to allow debugging again